### PR TITLE
fix: propagate $APPNAME through docker stages

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# Execute the binary with our arguments
+exec "$BINARY" "$@"


### PR DESCRIPTION
## Description

- add an entrypoint to read it via an ENV var (as CMD/ENTRYPOINT
exec forms don't interpolate it)
- add openssl

## Testing

Fixes deploying to the new dev env

## Issue(s)

Closes #25
