### PR TITLE
refactor: Move Dockerflow behavior into a module

### DIFF
--- a/src/web/dockerflow.rs
+++ b/src/web/dockerflow.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+
+use actix_web::{web, HttpRequest, HttpResponse};
+use serde_json::Value;
+
+use crate::error::HandlerError;
+
+// Known DockerFlow commands for Ops callbacks
+pub const DOCKER_FLOW_ENDPOINTS: [&str; 4] = [
+    "/__heartbeat__",
+    "/__lbheartbeat__",
+    "/__version__",
+    "/__error__",
+];
+
+/// Handles required Dockerflow Endpoints
+pub fn service(config: &mut web::ServiceConfig) {
+    config
+        .service(web::resource("/__lbheartbeat__").route(web::get().to(lbheartbeat)))
+        .service(web::resource("/__heartbeat__").route(web::get().to(heartbeat)))
+        .service(web::resource("/__version__").route(web::get().to(version)))
+        .service(web::resource("/__error__").route(web::get().to(test_error)));
+}
+
+/// Used by the load balancer to indicate that the server can respond to
+/// requests. Should just return OK.
+fn lbheartbeat(_: HttpRequest) -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .body("{}")
+}
+
+/// Return the contents of the `version.json` file created by CircleCI and stored
+/// in the Docker root (or the TBD version stored in the Git repo).
+fn version(_: HttpRequest) -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .body(include_str!("../../version.json"))
+}
+
+/// Returns a status message indicating the current state of the server
+fn heartbeat(_: HttpRequest) -> HttpResponse {
+    let mut checklist = HashMap::new();
+    checklist.insert(
+        "version".to_owned(),
+        Value::String(env!("CARGO_PKG_VERSION").to_owned()),
+    );
+    HttpResponse::Ok().json(checklist)
+}
+
+/// Returning an API error to test error handling
+async fn test_error(_: HttpRequest) -> Result<HttpResponse, HandlerError> {
+    // generate an error for sentry.
+    error!("Test Error");
+    Err(HandlerError::internal("Oh Noes!"))
+}

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -1,8 +1,5 @@
 //! API Handlers
-use std::collections::HashMap;
-
-use actix_web::{web, Error, HttpRequest, HttpResponse};
-use serde_json::Value;
+use actix_web::{web, HttpRequest, HttpResponse};
 
 use super::user_agent;
 use crate::{
@@ -78,21 +75,4 @@ pub async fn get_tiles(
     Ok(HttpResponse::Ok()
         .content_type("application/json")
         .body(tiles))
-}
-
-/// Returns a status message indicating the state of the current server
-pub async fn heartbeat() -> Result<HttpResponse, Error> {
-    let mut checklist = HashMap::new();
-    checklist.insert(
-        "version".to_owned(),
-        Value::String(env!("CARGO_PKG_VERSION").to_owned()),
-    );
-    Ok(HttpResponse::Ok().json(checklist))
-}
-
-/// try returning an API error
-pub async fn test_error() -> Result<HttpResponse, HandlerError> {
-    // generate an error for sentry.
-    error!("Test Error");
-    Err(HandlerError::internal("Oh Noes!"))
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,4 +1,5 @@
 //! Web authentication, handlers, and middleware
+pub mod dockerflow;
 pub mod extractors;
 pub mod handlers;
 pub mod middleware;
@@ -6,10 +7,4 @@ pub mod middleware;
 mod test;
 mod user_agent;
 
-// Known DockerFlow commands for Ops callbacks
-pub const DOCKER_FLOW_ENDPOINTS: [&str; 4] = [
-    "/__heartbeat__",
-    "/__lbheartbeat__",
-    "/__version__",
-    "/__error__",
-];
+pub use dockerflow::DOCKER_FLOW_ENDPOINTS;

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -13,7 +13,7 @@ use crate::{
     metrics::Metrics,
     server::{cache, ServerState},
     settings::{test_settings, Settings},
-    web::{handlers, middleware},
+    web::{dockerflow, handlers, middleware},
 };
 
 const MOCK_RESPONSE1: &str = include_str!("mock_adm_response1.json");


### PR DESCRIPTION
## Description

Move Dockerflow behavior into a module. This tidies up `src/server/mod.rs`, which I think makes it more approachable. This would have helped me navigate the project, since the previous Dockerflow implementation gave a lot of visual weight to a relatively unimportant behavior in the file.

It may be worth considering having a common module that other Mozilla services could use, based on this.

## Testing

This is a simple refactor, so all existing behavior should remain the same. Notable, the Dockerflow endpoints should still work, and the tests should still pass.

## Issue(s)

N/A
