### PR TITLE
bug: handle bad responses from ADM

### DIFF
--- a/src/adm.rs
+++ b/src/adm.rs
@@ -48,12 +48,17 @@ pub async fn get_tiles(
         .get(adm_url)
         .header(reqwest::header::USER_AGENT, stripped_ua)
         .send()
-        .await?
+        .await
+        .map_err(|e| {
+            // ADM servers are down, or improperly configured
+            HandlerErrorKind::BadAdmResponse(format!("ADM Server Error: {:?}", e))
+        })?
         .error_for_status()?
         .json()
         .await
         .map_err(|e| {
-            HandlerErrorKind::BadAdmResponse(format!("Returned invalid response: {:?}", e))
+            // ADM servers are not returning correct information
+            HandlerErrorKind::BadAdmResponse(format!("ADM provided invalid response: {:?}", e))
         })?;
     response.tiles = response
         .tiles

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,9 @@ pub enum HandlerErrorKind {
 
     #[error("Location error: {:?}", _0)]
     Location(String),
+
+    #[error("Bad Adm response: {:?}", _0)]
+    BadAdmResponse(String),
 }
 
 impl HandlerErrorKind {
@@ -55,6 +58,7 @@ impl HandlerErrorKind {
             HandlerErrorKind::General(_) => 500,
             HandlerErrorKind::Internal(_) => 510,
             HandlerErrorKind::Reqwest(_) => 520,
+            HandlerErrorKind::BadAdmResponse(_) => 521,
             HandlerErrorKind::Validation(_) => 600,
             HandlerErrorKind::Location(_) => 530,
         }

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -122,8 +122,10 @@ pub async fn get_tiles(
                 // (This is starting to become a pattern. 🤔)
                 let mut tags = Tags::from(request.head());
                 tags.add_extra("err", es);
+                tags.add_tag("level", "warning");
                 l_sentry::report(&tags, sentry::event_from_error(&e));
                 //TODO: probably should do: json!(vec![adm::AdmTile::default()]).to_string()
+                warn!("ADM Server error: {:?}", e);
                 "[]".to_owned()
             }
             _ => return Err(e),

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -1,6 +1,7 @@
 //! API Handlers
 use actix_http::http::Uri;
 use actix_web::{web, HttpRequest, HttpResponse};
+use serde_json::json;
 
 use super::user_agent;
 use crate::{
@@ -126,7 +127,7 @@ pub async fn get_tiles(
                 l_sentry::report(&tags, sentry::event_from_error(&e));
                 //TODO: probably should do: json!(vec![adm::AdmTile::default()]).to_string()
                 warn!("ADM Server error: {:?}", e);
-                "[]".to_owned()
+                json!({"tiles":[]}).to_string()
             }
             _ => return Err(e),
         },


### PR DESCRIPTION
## Description

ADM can sometimes return invalid content (e.g. a 200 response with no
"tiles".

Report this to sentry, and log, but we return an "empty" value to the
client.

## Testing

A bit difficult, since this will query the ADM service directly. It's possible to use an external service which returns an invalid response value (e.g. 
```
echo -e "HTTP/1.1 200\ncontent-length:2\content-type:application/json\n\n{}" | nc -l -p 8080 
```
and set the `CONTILE_ADM_ENDPOINT="http://localhost:8080"`
*Note, this is an example only. the response may not be fully valid HTTP

## Issue(s)

Closes #55
