### PR TITLE
feat: minor updates per the latest Tiles API

### DIFF
--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -49,7 +49,6 @@ pub async fn get_tiles(
         &[
             ("partner", settings.partner_id.as_str()),
             ("sub1", settings.sub1.as_str()),
-            ("ip", &location.fake_ip), // TODO: remove once ADM API finalized
             ("country-code", &location.country()),
             ("region-code", &location.region()),
             // ("dma-code", location.dma),

--- a/src/server/cache.rs
+++ b/src/server/cache.rs
@@ -22,7 +22,8 @@ pub struct AudienceKey {
     pub region_code: String,
     /// The form-factor (e.g. desktop, phone) of the device
     pub form_factor: FormFactor,
-    // XXX: this may not be a targetting parameter? (if so it shouldn't be here)
+    // XXX: *not* currently a targetting parameter (shouldn't be here),
+    // temporarily needed for tile_cache_updater
     /// The family of Operating System (e.g. windows, macos) of the device
     pub os_family: OsFamily,
 }

--- a/src/server/location.rs
+++ b/src/server/location.rs
@@ -17,7 +17,6 @@ const GOOG_LOC_HEADER: &str = "x-client-geo-location";
 /// The returned, stripped location.
 #[derive(Serialize, Debug, Default, Clone)]
 pub struct LocationResult {
-    pub fake_ip: String, // TODO: remove once ADM API is finalized
     #[serde(skip_serializing_if = "Option::is_none")]
     pub city: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/web/mock_adm_response1.json
+++ b/src/web/mock_adm_response1.json
@@ -3,7 +3,7 @@
         {
             "id": 601,
             "name": "Acme",
-            "click_url": "https://example.com/ctp?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000&aespFlag=altinst",
+            "click_url": "https://example.com/ctp?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000",
             "image_url": "https://cdn.example.com/601.jpg",
             "advertiser_url": "https://www.acme.biz/?foo=1&device=Computers&cmpgn=123601",
             "impression_url": "https://example.net/static?id=0000"
@@ -11,7 +11,7 @@
         {
             "id": 703,
             "name": "Dunder Mifflin",
-            "click_url": "https://example.com/ctp?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A&aespFlag=altinst",
+            "click_url": "https://example.com/ctp?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A",
             "image_url": "https://cdn.example.com/703.jpg",
             "advertiser_url": "https://www.dunderm.biz/?tag=bar&ref=baz",
             "impression_url": "https://example.com/static?id=DEADB33F"
@@ -19,7 +19,7 @@
         {
             "id": 805,
             "name": "Los Pollos Hermanos",
-            "click_url": "https://example.com/ctp?version=16.0.0&key=3.3&ci=4.4&ctag=1612376952400200000&aespFlag=altinst",
+            "click_url": "https://example.com/ctp?version=16.0.0&key=3.3&ci=4.4&ctag=1612376952400200000",
             "image_url": "https://cdn.example.com/805.jpg",
             "advertiser_url": "https://www.lph-nm.biz/?utm_source=google&utm_campaign=quux*{keyword}_m*{match-type}_d*BARBAZ_22",
             "impression_url": "https://example.net/static?id=ABAD1DEA"

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -163,12 +163,12 @@ async fn basic() {
 
 #[actix_rt::test]
 async fn basic_bad_reply() {
-    let missing_aespflag = r#"{
+    let missing_ci = r#"{
         "tiles": [
             {
                 "id": 601,
                 "name": "Acme",
-                "click_url": "https://example.com/ctp?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000",
+                "click_url": "https://example.com/ctp?version=16.0.0&key=22.1&ctag=1612376952400200000",
                 "image_url": "https://cdn.example.com/601.jpg",
                 "advertiser_url": "https://www.acme.biz/?foo=1&device=Computers&cmpgn=123601",
                 "impression_url": "https://example.net/static?id=0000"
@@ -176,13 +176,13 @@ async fn basic_bad_reply() {
             {
                 "id": 703,
                 "name": "Dunder Mifflin",
-                "click_url": "https://example.com/ctp?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A&aespFlag=altinst",
+                "click_url": "https://example.com/ctp?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A",
                 "image_url": "https://cdn.example.com/703.jpg",
                 "advertiser_url": "https://www.dunderm.biz/?tag=bar&ref=baz",
                 "impression_url": "https://example.net/static?id=DEADB33F"
             }
         ]}"#;
-    let (_, addr) = init_mock_adm(missing_aespflag.to_owned());
+    let (_, addr) = init_mock_adm(missing_ci.to_owned());
     let settings = Settings {
         adm_endpoint_url: format!("http://{}:{}/?partner=foo&sub1=bar", addr.ip(), addr.port()),
         adm_settings: json!(adm_settings()).to_string(),


### PR DESCRIPTION
## Description

- click_url's aespFlag parameter is deprecated
- note os-family isn't currently for targeting
- include more metadata in sentry errors

## Testing

Fixes dev/stage to return tiles

## Issue(s)

Closes #96
