### PR TITLE
feat: Add a setting which defines a custom location header

### DIFF
--- a/src/server/location.rs
+++ b/src/server/location.rs
@@ -32,9 +32,9 @@ pub struct LocationResult {
 /// Read the [RequestHead] from either [HttpRequest] and [ServiceRequest]
 /// and pull the user location
 impl LocationResult {
-    pub fn from_header(head: &RequestHead, settings: Settings) -> Self {
+    pub fn from_header(head: &RequestHead, settings: &Settings) -> Self {
         let headers = head.headers();
-        if let Some(loc_header) = settings.location_test_header {
+        if let Some(ref loc_header) = settings.location_test_header {
             if let Some(header) = headers.get(loc_header) {
                 dbg!("Using test header");
                 return Self::from_headervalue(header);
@@ -410,9 +410,9 @@ mod test {
             HeaderValue::from_static(&hv),
         );
 
-        let loc = LocationResult::from_header(&test_head, settings);
-        assert!(loc.region() == "CA".to_owned());
-        assert!(loc.country() == "US".to_owned());
+        let loc = LocationResult::from_header(&test_head, &settings);
+        assert!(loc.region() == *"CA");
+        assert!(loc.country() == *"US");
         Ok(())
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -74,6 +74,8 @@ pub struct Settings {
     pub partner_id: String,
     /// Adm sub1 value (default: "123456789")
     pub sub1: String,
+    /// Location test header override
+    pub location_test_header: Option<String>,
 }
 
 impl Default for Settings {
@@ -97,6 +99,7 @@ impl Default for Settings {
             storage: "".to_owned(),
             partner_id: "demofeed".to_owned(),
             sub1: "123456789".to_owned(),
+            location_test_header: None,
         }
     }
 }

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -25,6 +25,7 @@ pub async fn get_tiles(
     trace!("get_tiles");
 
     let cinfo = request.connection_info();
+    let settings = state.settings.clone();
     let ip_addr_str = cinfo.remote_addr().unwrap_or({
         let default = state
             .adm_country_ip_map
@@ -50,9 +51,9 @@ pub async fn get_tiles(
             .mmdb
             .mmdb_locate(addr, &["en".to_owned()])
             .await
-            .unwrap_or_else(|_| Some(LocationResult::from(header)))
+            .unwrap_or_else(|_| Some(LocationResult::from_header(header, settings)))
     } else {
-        Some(LocationResult::from(header))
+        Some(LocationResult::from_header(header, settings))
     }
     .unwrap_or_default();
 

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -25,7 +25,6 @@ pub async fn get_tiles(
     trace!("get_tiles");
 
     let cinfo = request.connection_info();
-    let settings = state.settings.clone();
     let ip_addr_str = cinfo.remote_addr().unwrap_or({
         let default = state
             .adm_country_ip_map
@@ -51,9 +50,9 @@ pub async fn get_tiles(
             .mmdb
             .mmdb_locate(addr, &["en".to_owned()])
             .await
-            .unwrap_or_else(|_| Some(LocationResult::from_header(header, settings)))
+            .unwrap_or_else(|_| Some(LocationResult::from_header(header, &state.settings)))
     } else {
-        Some(LocationResult::from_header(header, settings))
+        Some(LocationResult::from_header(header, &state.settings))
     }
     .unwrap_or_default();
 


### PR DESCRIPTION
Closes #101

## Description

This adds a new setting: `location_test_header` which can be used to
specify a custom, testing location request header (e.g. `Test-Location`
which can contain a false test location for the request. This flag is
not meant for use in a production environment. If the header is not
present, the server will fall back on the normal location determination
code.

## Testing

unit test included.

## Issue(s)

Closes #101
