### PR TITLE
feat: Add improved response codes

### DIFF
--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -71,7 +71,7 @@ pub async fn get_tiles(
         .await
         .map_err(|e| {
             // ADM servers are down, or improperly configured
-            HandlerErrorKind::BadAdmResponse(format!("ADM Server Error: {:?}", e))
+            HandlerErrorKind::AdmServerError(e.to_string())
         })?
         .error_for_status()?
         .json()

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,6 +67,10 @@ pub enum HandlerErrorKind {
     /// ADM returned an invalid or unexpected response
     #[error("Bad Adm response: {:?}", _0)]
     BadAdmResponse(String),
+
+    /// ADM Servers returned an error
+    #[error("Adm Server Error: {:?}", _0)]
+    AdmServerError(String),
 }
 
 /// A set of Error Context utilities
@@ -75,6 +79,8 @@ impl HandlerErrorKind {
     pub fn http_status(&self) -> StatusCode {
         match self {
             HandlerErrorKind::Validation(_) => StatusCode::BAD_REQUEST,
+            HandlerErrorKind::AdmServerError(_) => StatusCode::SERVICE_UNAVAILABLE,
+            HandlerErrorKind::BadAdmResponse(_) => StatusCode::BAD_GATEWAY,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -86,6 +92,7 @@ impl HandlerErrorKind {
             HandlerErrorKind::Internal(_) => 510,
             HandlerErrorKind::Reqwest(_) => 520,
             HandlerErrorKind::BadAdmResponse(_) => 521,
+            HandlerErrorKind::AdmServerError(_) => 522,
             HandlerErrorKind::Validation(_) => 600,
             HandlerErrorKind::InvalidHost(_, _) => 601,
             HandlerErrorKind::UnexpectedHost(_, _) => 602,

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -127,7 +127,5 @@ pub async fn get_tiles(
         },
     };
 
-    Ok(reply
-        .content_type("application/json")
-        .body(tiles))
+    Ok(reply.content_type("application/json").body(tiles))
 }

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -222,6 +222,44 @@ async fn basic_bad_reply() {
 }
 
 #[actix_rt::test]
+async fn basic_all_bad_reply() {
+    let missing_ci = r#"{
+        "tiles": [
+            {
+                "id": 601,
+                "name": "Acme",
+                "click_url": "https://example.com/ctp?version=16.0.0&key=22.1&ctag=1612376952400200000",
+                "image_url": "https://cdn.example.com/601.jpg",
+                "advertiser_url": "https://www.acme.biz/?foo=1&device=Computers&cmpgn=123601",
+                "impression_url": "https://example.net/static?id=0000"
+            },
+            {
+                "id": 703,
+                "name": "Dunder Mifflin",
+                "click_url": "https://example.com/ctp?version=16.0.0&key=7.2&ci=8.9",
+                "image_url": "https://cdn.example.com/703.jpg",
+                "advertiser_url": "https://www.dunderm.biz/?tag=bar&ref=baz",
+                "impression_url": "https://example.net/static?id=DEADB33F"
+            }
+        ]}"#;
+    let (_, addr) = init_mock_adm(missing_ci.to_owned());
+    let settings = Settings {
+        adm_endpoint_url: format!("http://{}:{}/?partner=foo&sub1=bar", addr.ip(), addr.port()),
+        adm_settings: json!(adm_settings()).to_string(),
+        ..get_test_settings()
+    };
+    let mut app = init_app!(settings).await;
+
+    let req = test::TestRequest::get()
+        .uri("/v1/tiles?country=US&placement=newtab")
+        .header(header::USER_AGENT, UA)
+        .to_request();
+    let resp = test::call_service(&mut app, req).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+
+#[actix_rt::test]
 async fn basic_filtered() {
     let (_, addr) = init_mock_adm(MOCK_RESPONSE1.to_owned());
 

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -258,7 +258,6 @@ async fn basic_all_bad_reply() {
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 }
 
-
 #[actix_rt::test]
 async fn basic_filtered() {
     let (_, addr) = init_mock_adm(MOCK_RESPONSE1.to_owned());


### PR DESCRIPTION
Closes: #92

## Description

Add improved response codes:
200 - tiles included
204 - No tile content included
502 - ADM returned a 500 
503 - ADM returned a general error

## Testing

Unit test included

## Issue(s)

Issue #92
