### PR TITLE
bug: only permit Firefox UA from querying contile

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,10 @@ pub enum HandlerErrorKind {
     /// ADM Servers returned an error
     #[error("Adm Server Error: {:?}", _0)]
     AdmServerError(String),
+
+    /// Invalid UserAgent request
+    #[error("Invalid user agent: {:?}", _0)]
+    InvalidUA(String),
 }
 
 /// A set of Error Context utilities
@@ -81,6 +85,7 @@ impl HandlerErrorKind {
             HandlerErrorKind::Validation(_) => StatusCode::BAD_REQUEST,
             HandlerErrorKind::AdmServerError(_) => StatusCode::SERVICE_UNAVAILABLE,
             HandlerErrorKind::BadAdmResponse(_) => StatusCode::BAD_GATEWAY,
+            &HandlerErrorKind::InvalidUA(_) => StatusCode::FORBIDDEN,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -93,12 +98,13 @@ impl HandlerErrorKind {
             HandlerErrorKind::Reqwest(_) => 520,
             HandlerErrorKind::BadAdmResponse(_) => 521,
             HandlerErrorKind::AdmServerError(_) => 522,
+            HandlerErrorKind::Location(_) => 530,
             HandlerErrorKind::Validation(_) => 600,
             HandlerErrorKind::InvalidHost(_, _) => 601,
             HandlerErrorKind::UnexpectedHost(_, _) => 602,
             HandlerErrorKind::MissingHost(_, _) => 603,
             HandlerErrorKind::UnexpectedAdvertiser(_) => 604,
-            HandlerErrorKind::Location(_) => 530,
+            HandlerErrorKind::InvalidUA(_) => 700,
         }
     }
 

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -35,7 +35,7 @@ pub async fn get_tiles(
             default
         }
     });
-    let (os_family, form_factor) = user_agent::get_device_info(&treq.ua);
+    let (os_family, form_factor) = user_agent::get_device_info(&treq.ua)?;
 
     let header = request.head();
     let location = if state.mmdb.is_available() {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -8,4 +8,4 @@ mod test;
 mod user_agent;
 
 pub use dockerflow::DOCKER_FLOW_ENDPOINTS;
-pub use user_agent::{strip_ua, FormFactor, OsFamily};
+pub use user_agent::{FormFactor, OsFamily};

--- a/src/web/user_agent.rs
+++ b/src/web/user_agent.rs
@@ -210,7 +210,7 @@ mod tests {
         let result = get_device_info("Mozilla/5.0 (X11; CrOS x86_64 13816.64.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.100 Safari/537.36");
         assert!(result.is_err());
         match result.unwrap_err().kind() {
-            &HandlerErrorKind::InvalidUA(_) => {}
+            HandlerErrorKind::InvalidUA(_) => {}
             _ => panic!("Incorrect error returned for test"),
         }
     }

--- a/src/web/user_agent.rs
+++ b/src/web/user_agent.rs
@@ -79,7 +79,6 @@ pub fn get_device_info(ua: &str) -> HandlerResult<(OsFamily, FormFactor)> {
     let wresult = Parser::new().parse(ua).unwrap_or_default();
 
     // If it's not firefox, it doesn't belong here...
-    // are there other names that could be returned? (e.g. for the iOS version)
     if !["firefox"].contains(&wresult.name.to_lowercase().as_str()) {
         return Err(HandlerErrorKind::InvalidUA(ua.to_owned()).into());
     }


### PR DESCRIPTION
Closes: #124

## Description

Exclude non-firefox User Agents from getting results from Contile

## Testing

Tests included, but please try fetching tiles from `/v1/tiles` with various versions of firefox and other UAs to ensure that only firefox gets results. 

## Issue(s)

Closes #124
