### PR TITLE
feat: redirect root requests to official documentation

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -82,6 +82,8 @@ pub struct Settings {
     pub location_test_header: Option<String>,
     /// Default location (if no location info is able to be determined for an IP)
     pub fallback_location: String,
+    /// URL to the official documentation
+    pub documentation_url: String,
 }
 
 impl Default for Settings {
@@ -109,6 +111,7 @@ impl Default for Settings {
             test_file_path: "./tools/test/test_data/".to_owned(),
             location_test_header: None,
             fallback_location: "USOK".to_owned(),
+            documentation_url: "https://developer.mozilla.org/".to_owned(),
         }
     }
 }

--- a/src/web/dockerflow.rs
+++ b/src/web/dockerflow.rs
@@ -11,6 +11,7 @@ use actix_web::{web, HttpRequest, HttpResponse};
 use serde_json::Value;
 
 use crate::error::HandlerError;
+use crate::server::ServerState;
 
 /// Well Known DockerFlow commands for Ops callbacks
 pub const DOCKER_FLOW_ENDPOINTS: [&str; 4] = [
@@ -26,7 +27,8 @@ pub fn service(config: &mut web::ServiceConfig) {
         .service(web::resource("/__lbheartbeat__").route(web::get().to(lbheartbeat)))
         .service(web::resource("/__heartbeat__").route(web::get().to(heartbeat)))
         .service(web::resource("/__version__").route(web::get().to(version)))
-        .service(web::resource("/__error__").route(web::get().to(test_error)));
+        .service(web::resource("/__error__").route(web::get().to(test_error)))
+        .service(web::resource("").route(web::get().to(document_boot)));
 }
 
 /// Used by the load balancer to indicate that the server can respond to
@@ -60,4 +62,14 @@ async fn test_error(_: HttpRequest) -> Result<HttpResponse, HandlerError> {
     // generate an error for sentry.
     error!("Test Error");
     Err(HandlerError::internal("Oh Noes!"))
+}
+
+async fn document_boot(
+    _: HttpRequest,
+    state: web::Data<ServerState>,
+) -> Result<HttpResponse, HandlerError> {
+    let settings = &state.settings;
+    return Ok(HttpResponse::SeeOther()
+        .header("Location", settings.documentation_url.clone())
+        .finish());
 }

--- a/src/web/dockerflow.rs
+++ b/src/web/dockerflow.rs
@@ -66,7 +66,7 @@ async fn test_error() -> Result<HttpResponse, HandlerError> {
 
 async fn document_boot(state: web::Data<ServerState>) -> Result<HttpResponse, HandlerError> {
     let settings = &state.settings;
-    return Ok(HttpResponse::SeeOther()
+    return Ok(HttpResponse::Found()
         .header("Location", settings.documentation_url.clone())
         .finish());
 }

--- a/src/web/dockerflow.rs
+++ b/src/web/dockerflow.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use actix_web::{web, HttpRequest, HttpResponse};
+use actix_web::{web, HttpResponse};
 use serde_json::Value;
 
 use crate::error::HandlerError;
@@ -33,7 +33,7 @@ pub fn service(config: &mut web::ServiceConfig) {
 
 /// Used by the load balancer to indicate that the server can respond to
 /// requests. Should just return OK.
-fn lbheartbeat(_: HttpRequest) -> HttpResponse {
+fn lbheartbeat() -> HttpResponse {
     HttpResponse::Ok()
         .content_type("application/json")
         .body("{}")
@@ -41,14 +41,14 @@ fn lbheartbeat(_: HttpRequest) -> HttpResponse {
 
 /// Return the contents of the `version.json` file created by CircleCI and stored
 /// in the Docker root (or the TBD version stored in the Git repo).
-fn version(_: HttpRequest) -> HttpResponse {
+fn version() -> HttpResponse {
     HttpResponse::Ok()
         .content_type("application/json")
         .body(include_str!("../../version.json"))
 }
 
 /// Returns a status message indicating the current state of the server
-fn heartbeat(_: HttpRequest) -> HttpResponse {
+fn heartbeat() -> HttpResponse {
     let mut checklist = HashMap::new();
     checklist.insert(
         "version".to_owned(),
@@ -58,16 +58,13 @@ fn heartbeat(_: HttpRequest) -> HttpResponse {
 }
 
 /// Returning an API error to test error handling
-async fn test_error(_: HttpRequest) -> Result<HttpResponse, HandlerError> {
+async fn test_error() -> Result<HttpResponse, HandlerError> {
     // generate an error for sentry.
     error!("Test Error");
     Err(HandlerError::internal("Oh Noes!"))
 }
 
-async fn document_boot(
-    _: HttpRequest,
-    state: web::Data<ServerState>,
-) -> Result<HttpResponse, HandlerError> {
+async fn document_boot(state: web::Data<ServerState>) -> Result<HttpResponse, HandlerError> {
     let settings = &state.settings;
     return Ok(HttpResponse::SeeOther()
         .header("Location", settings.documentation_url.clone())


### PR DESCRIPTION
Closes: #131

## Description

Redirects root GET requests to official documentation URL

## Testing

`curl -v http://{host}` should return a 303 with a `location` header set to the `settings.documentation_url`

## Issue(s)

Closes #131

┆Issue is synchronized with this [Jira Bug](https://jira.mozilla.com/browse/CONSVC-170)
