### PR TITLE
feat: add timeout for calls to ADM service

### DIFF
--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, fs::File, io::BufReader, path::Path};
+use std::{fmt::Debug, fs::File, io::BufReader, path::Path, time::Duration};
 
 use actix_http::http::header::{HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
@@ -156,6 +156,7 @@ pub async fn get_tiles(
     } else {
         reqwest_client
             .get(adm_url)
+            .timeout(Duration::from_secs(settings.adm_timeout))
             .send()
             .await
             .map_err(|e| {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -58,6 +58,8 @@ pub struct Settings {
     pub adm_max_tiles: u8,
     /// number of tiles to query from ADM (default: 10)
     pub adm_query_tile_count: u8,
+    /// Timeout requests to the ADM server after this many seconds (default: 3)
+    pub adm_timeout: u64,
     /// Expire tiles after this many seconds (15 * 60s)
     pub tiles_ttl: u32,
     /// ADM tile settings (either as JSON or a path to a JSON file)
@@ -101,6 +103,7 @@ impl Default for Settings {
             adm_country_ip_map: DEFAULT_ADM_COUNTRY_IP_MAP.to_owned(),
             adm_max_tiles: 2,
             adm_query_tile_count: 10,
+            adm_timeout: 5,
             tiles_ttl: 15 * 60,
             adm_settings: "".to_owned(),
             maxminddb_loc: None,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -82,6 +82,8 @@ pub struct Settings {
     pub location_test_header: Option<String>,
     /// Default location (if no location info is able to be determined for an IP)
     pub fallback_location: String,
+    /// URL to the official documentation
+    pub documentation_url: String,
 }
 
 impl Default for Settings {
@@ -109,6 +111,7 @@ impl Default for Settings {
             test_file_path: "./tools/test/test_data/".to_owned(),
             location_test_header: None,
             fallback_location: "USOK".to_owned(),
+            documentation_url: "https://developer.mozilla.org/".to_owned(),
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -58,7 +58,7 @@ pub struct Settings {
     pub adm_max_tiles: u8,
     /// number of tiles to query from ADM (default: 10)
     pub adm_query_tile_count: u8,
-    /// Timeout requests to the ADM server after this many seconds (default: 3)
+    /// Timeout requests to the ADM server after this many seconds (default: 5)
     pub adm_timeout: u64,
     /// Expire tiles after this many seconds (15 * 60s)
     pub tiles_ttl: u32,

--- a/src/web/dockerflow.rs
+++ b/src/web/dockerflow.rs
@@ -11,6 +11,7 @@ use actix_web::{web, HttpRequest, HttpResponse};
 use serde_json::Value;
 
 use crate::error::HandlerError;
+use crate::server::ServerState;
 
 /// Well Known DockerFlow commands for Ops callbacks
 pub const DOCKER_FLOW_ENDPOINTS: [&str; 4] = [
@@ -26,7 +27,8 @@ pub fn service(config: &mut web::ServiceConfig) {
         .service(web::resource("/__lbheartbeat__").route(web::get().to(lbheartbeat)))
         .service(web::resource("/__heartbeat__").route(web::get().to(heartbeat)))
         .service(web::resource("/__version__").route(web::get().to(version)))
-        .service(web::resource("/__error__").route(web::get().to(test_error)));
+        .service(web::resource("/__error__").route(web::get().to(test_error)))
+        .service(web::resource("").route(web::get().to(document_boot)));
 }
 
 /// Used by the load balancer to indicate that the server can respond to
@@ -60,4 +62,14 @@ async fn test_error(_: HttpRequest) -> Result<HttpResponse, HandlerError> {
     // generate an error for sentry.
     error!("Test Error");
     Err(HandlerError::internal("Oh Noes!"))
+}
+
+async fn document_boot(
+    _: HttpRequest,
+    state: web::Data<ServerState>,
+) -> Result<HttpResponse, HandlerError> {
+    let settings = &state.settings;
+    return Ok(HttpResponse::SeeOther()
+        .header("Location", settings.documentation_url.clone())
+        .finish());
 }


### PR DESCRIPTION
## Description

* Uses setting `adm_timeout`, and defaults to 5 seconds
I suspect that we probably may have different timeouts for various
partners. There is no timeout specified for a default reqwest builder.

## Testing

requests to ADM should take no longer than 5 seconds in default setting

## Issue(s)

Closes #139
