### PR TITLE
Feat/123 ignore

### DIFF
--- a/src/adm/filter.rs
+++ b/src/adm/filter.rs
@@ -37,6 +37,7 @@ lazy_static! {
 #[derive(Default, Clone, Debug)]
 pub struct AdmFilter {
     pub filter_set: HashMap<String, AdmAdvertiserFilterSettings>,
+    pub ignore_list: HashSet<String>,
 }
 
 /// Extract the host from Url
@@ -269,11 +270,13 @@ impl AdmFilter {
                 ))
             }
             None => {
-                metrics.incr_with_tags("filter.adm.err.unexpected_advertiser", Some(tags));
-                self.report(
-                    &HandlerErrorKind::UnexpectedAdvertiser(tile.name).into(),
-                    tags,
-                );
+                if !self.ignore_list.contains(&tile.name.to_lowercase()) {
+                    metrics.incr_with_tags("filter.adm.err.unexpected_advertiser", Some(tags));
+                    self.report(
+                        &HandlerErrorKind::UnexpectedAdvertiser(tile.name).into(),
+                        tags,
+                    );
+                }
                 None
             }
         }

--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -126,8 +126,8 @@ pub async fn get_tiles(
     let adm_url = Url::parse_with_params(
         adm_endpoint_url,
         &[
-            ("partner", settings.adm_partner_id.as_str()),
-            ("sub1", settings.adm_sub1.as_str()),
+            ("partner", settings.adm_partner_id.clone().unwrap().as_str()),
+            ("sub1", settings.adm_sub1.clone().unwrap().as_str()),
             ("country-code", &location.country()),
             ("region-code", &location.region()),
             // ("dma-code", location.dma),

--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -126,8 +126,8 @@ pub async fn get_tiles(
     let adm_url = Url::parse_with_params(
         adm_endpoint_url,
         &[
-            ("partner", settings.partner_id.as_str()),
-            ("sub1", settings.sub1.as_str()),
+            ("partner", settings.adm_partner_id.as_str()),
+            ("sub1", settings.adm_sub1.as_str()),
             ("country-code", &location.country()),
             ("region-code", &location.region()),
             // ("dma-code", location.dma),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -86,8 +86,8 @@ macro_rules! build_app {
 
 impl Server {
     /// initialize a new instance of the server from [Settings]
-    pub async fn with_settings(settings: Settings) -> Result<dev::Server, HandlerError> {
-        let filter = HandlerResult::<AdmFilter>::from(&settings)?;
+    pub async fn with_settings(mut settings: Settings) -> Result<dev::Server, HandlerError> {
+        let filter = HandlerResult::<AdmFilter>::from(&mut settings)?;
         let state = ServerState {
             metrics: Box::new(metrics_from_opts(&settings)?),
             adm_endpoint_url: settings.adm_endpoint_url.clone(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -69,9 +69,9 @@ pub struct Settings {
 
     // TODO: break these out into a PartnerSettings?
     /// Adm partner ID (default: "demofeed")
-    pub adm_partner_id: String,
+    pub adm_partner_id: Option<String>,
     /// Adm sub1 value (default: "123456789")
-    pub adm_sub1: String,
+    pub adm_sub1: Option<String>,
     /// adm Endpoint URL
     pub adm_endpoint_url: String,
     /// adm country to default IP map (Hash in JSON format)
@@ -90,6 +90,10 @@ pub struct Settings {
     pub adm_settings: String,
     /// A JSON list of advertisers to ignore, specified by the Advertiser name.
     pub adm_ignore_advertisers: Option<String>,
+
+    // OBSOLETE:
+    pub sub1: Option<String>,
+    pub partner_id: Option<String>,
 }
 
 impl Default for Settings {
@@ -114,14 +118,16 @@ impl Default for Settings {
             documentation_url: "https://developer.mozilla.org/".to_owned(),
             // ADM specific settings
             adm_endpoint_url: "".to_owned(),
-            adm_partner_id: "demofeed".to_owned(),
-            adm_sub1: "123456789".to_owned(),
+            adm_partner_id: Some("demofeed".to_owned()),
+            adm_sub1: Some("123456789".to_owned()),
             adm_country_ip_map: DEFAULT_ADM_COUNTRY_IP_MAP.to_owned(),
             adm_max_tiles: 2,
             adm_query_tile_count: 10,
             adm_timeout: 5,
             adm_settings: "".to_owned(),
             adm_ignore_advertisers: None,
+            sub1: None,
+            partner_id: None,
         }
     }
 }
@@ -134,7 +140,7 @@ impl Settings {
         self.fallback_location = Location::fix(&self.fallback_location)?;
         // preflight check the storage
         StorageSettings::from(&*self);
-        AdmSettings::from(&*self);
+        AdmSettings::from(&mut *self);
         Ok(())
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -50,32 +50,12 @@ pub struct Settings {
     pub statsd_port: u16,
     /// Enable actix "keep alive" period in seconds (default: None)
     pub actix_keep_alive: Option<u64>,
-    /// adm Endpoint URL
-    pub adm_endpoint_url: String,
-    /// adm country to default IP map (Hash in JSON format)
-    pub adm_country_ip_map: String,
-    /// max tiles to accept from ADM (default: 2)
-    pub adm_max_tiles: u8,
-    /// number of tiles to query from ADM (default: 10)
-    pub adm_query_tile_count: u8,
-    /// Timeout requests to the ADM server after this many seconds (default: 5)
-    pub adm_timeout: u64,
     /// Expire tiles after this many seconds (15 * 60s)
     pub tiles_ttl: u32,
-    /// ADM tile settings (either as JSON or a path to a JSON file)
-    /// This consists of an advertiser name, and the associated filter settings
-    /// (e.g. ```{"Example":{"advertizer_hosts":["example.com"."example.org"]}})```)
-    /// Unspecfied [crate::adm::AdmAdvertiserFilterSettings] will use Default values specified
-    /// in `Default` (or the application default if not specified)
-    pub adm_settings: String,
     /// path to MaxMind location database
     pub maxminddb_loc: Option<String>,
     /// [StorageSettings] related to the google cloud storage
     pub storage: String,
-    /// Adm partner ID (default: "demofeed")
-    pub partner_id: String,
-    /// Adm sub1 value (default: "123456789")
-    pub sub1: String,
     /// Run in "integration test mode"
     pub test_mode: bool,
     /// path to the test files
@@ -86,11 +66,36 @@ pub struct Settings {
     pub fallback_location: String,
     /// URL to the official documentation
     pub documentation_url: String,
+
+    // TODO: break these out into a PartnerSettings?
+    /// Adm partner ID (default: "demofeed")
+    pub adm_partner_id: String,
+    /// Adm sub1 value (default: "123456789")
+    pub adm_sub1: String,
+    /// adm Endpoint URL
+    pub adm_endpoint_url: String,
+    /// adm country to default IP map (Hash in JSON format)
+    pub adm_country_ip_map: String,
+    /// max tiles to accept from ADM (default: 2)
+    pub adm_max_tiles: u8,
+    /// number of tiles to query from ADM (default: 10)
+    pub adm_query_tile_count: u8,
+    /// Timeout requests to the ADM server after this many seconds (default: 5)
+    pub adm_timeout: u64,
+    /// ADM tile settings (either as JSON or a path to a JSON file)
+    /// This consists of an advertiser name, and the associated filter settings
+    /// (e.g. ```{"Example":{"advertizer_hosts":["example.com"."example.org"]}})```)
+    /// Unspecfied [crate::adm::AdmAdvertiserFilterSettings] will use Default values specified
+    /// in `Default` (or the application default if not specified)
+    pub adm_settings: String,
+    /// A JSON list of advertisers to ignore, specified by the Advertiser name.
+    pub adm_ignore_advertisers: Option<String>,
 }
 
 impl Default for Settings {
     fn default() -> Settings {
         Settings {
+            // General settings
             debug: false,
             port: DEFAULT_PORT,
             host: "localhost".to_owned(),
@@ -99,22 +104,24 @@ impl Default for Settings {
             statsd_host: None,
             statsd_port: 8125,
             actix_keep_alive: None,
-            adm_endpoint_url: "".to_owned(),
-            adm_country_ip_map: DEFAULT_ADM_COUNTRY_IP_MAP.to_owned(),
-            adm_max_tiles: 2,
-            adm_query_tile_count: 10,
-            adm_timeout: 5,
             tiles_ttl: 15 * 60,
-            adm_settings: "".to_owned(),
             maxminddb_loc: None,
             storage: "".to_owned(),
-            partner_id: "demofeed".to_owned(),
-            sub1: "123456789".to_owned(),
             test_mode: false,
             test_file_path: "./tools/test/test_data/".to_owned(),
             location_test_header: None,
             fallback_location: "USOK".to_owned(),
             documentation_url: "https://developer.mozilla.org/".to_owned(),
+            // ADM specific settings
+            adm_endpoint_url: "".to_owned(),
+            adm_partner_id: "demofeed".to_owned(),
+            adm_sub1: "123456789".to_owned(),
+            adm_country_ip_map: DEFAULT_ADM_COUNTRY_IP_MAP.to_owned(),
+            adm_max_tiles: 2,
+            adm_query_tile_count: 10,
+            adm_timeout: 5,
+            adm_settings: "".to_owned(),
+            adm_ignore_advertisers: None,
         }
     }
 }

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -48,7 +48,7 @@ macro_rules! init_app {
                 tiles_cache: cache::TilesCache::new(10),
                 mmdb: Location::from(&$settings),
                 settings: $settings.clone(),
-                filter: HandlerResult::<AdmFilter>::from(&$settings).unwrap(),
+                filter: HandlerResult::<AdmFilter>::from(&mut $settings).unwrap(),
             };
             test::init_service(build_app!(state)).await
         }
@@ -121,7 +121,7 @@ fn adm_settings() -> AdmSettings {
 #[actix_rt::test]
 async fn basic() {
     let (_, addr) = init_mock_adm(MOCK_RESPONSE1.to_owned());
-    let settings = Settings {
+    let mut settings = Settings {
         adm_endpoint_url: format!("http://{}:{}/?partner=foo&sub1=bar", addr.ip(), addr.port()),
         adm_settings: json!(adm_settings()).to_string(),
         ..get_test_settings()
@@ -177,7 +177,7 @@ async fn basic_bad_reply() {
             }
         ]}"#;
     let (_, addr) = init_mock_adm(missing_ci.to_owned());
-    let settings = Settings {
+    let mut settings = Settings {
         adm_endpoint_url: format!("http://{}:{}/?partner=foo&sub1=bar", addr.ip(), addr.port()),
         adm_settings: json!(adm_settings()).to_string(),
         ..get_test_settings()
@@ -237,7 +237,7 @@ async fn basic_all_bad_reply() {
             }
         ]}"#;
     let (_, addr) = init_mock_adm(missing_ci.to_owned());
-    let settings = Settings {
+    let mut settings = Settings {
         adm_endpoint_url: format!("http://{}:{}/?partner=foo&sub1=bar", addr.ip(), addr.port()),
         adm_settings: json!(adm_settings()).to_string(),
         ..get_test_settings()
@@ -270,7 +270,7 @@ async fn basic_filtered() {
     );
     adm_settings.remove("Dunder Mifflin");
 
-    let settings = Settings {
+    let mut settings = Settings {
         adm_endpoint_url: format!("http://{}:{}/?partner=foo&sub1=bar", addr.ip(), addr.port()),
         adm_settings: json!(adm_settings).to_string(),
         ..get_test_settings()
@@ -315,7 +315,7 @@ async fn basic_default() {
     let adm_settings = adm_settings();
     trace!("Settings: {:?}", &adm_settings);
 
-    let settings = Settings {
+    let mut settings = Settings {
         adm_endpoint_url: format!("http://{}:{}/?partner=foo&sub1=bar", addr.ip(), addr.port()),
         adm_settings: json!(adm_settings).to_string(),
         ..get_test_settings()
@@ -358,7 +358,7 @@ async fn basic_default() {
 #[actix_rt::test]
 async fn invalid_placement() {
     let (_, addr) = init_mock_adm(MOCK_RESPONSE1.to_owned());
-    let settings = Settings {
+    let mut settings = Settings {
         adm_endpoint_url: format!("http://{}:{}/?partner=foo&sub1=bar", addr.ip(), addr.port()),
         ..get_test_settings()
     };


### PR DESCRIPTION
Closes #123

## Description

Adds `adm_ignore_advertisers` optional JSON formatted list of ignored advertisers

**Note** this is a non-breaking change currently, but the following arguments are now considered OBSOLETE and will generate a warning. Expect that these values will be dropped in a future version.

* `sub1`  | `CONTILE_SUB1` => `adm_sub1` | `CONTILE_ADM_SUB1`
* `partner_id` | `CONTILE_PARTNER_ID` => `adm_partner_id` | `CONTILE_PARTNER_ID`

## Testing

unit test included.

## Issue(s)

Closes #123
