### PR TITLE
feat: add an optional trace header to metrics/logging

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -208,20 +208,17 @@ impl Settings {
     }
 }
 
-// TODO: someone better at lifetimes could fix these.
-// The returned settings need only last as long as the request.
-// we clone to break out of the Arc
-impl From<&HttpRequest> for Settings {
-    fn from(req: &HttpRequest) -> Self {
+impl<'a> From<&'a HttpRequest> for &'a Settings {
+    fn from(req: &'a HttpRequest) -> Self {
         let state = req.app_data::<Data<ServerState>>().expect("No State!");
-        state.settings.clone()
+        &state.settings
     }
 }
 
-impl From<&ServiceRequest> for Settings {
-    fn from(req: &ServiceRequest) -> Self {
+impl<'a> From<&'a ServiceRequest> for &'a Settings {
+    fn from(req: &'a ServiceRequest) -> Self {
         let state = req.app_data::<Data<ServerState>>().expect("No State!");
-        state.settings.clone()
+        &state.settings
     }
 }
 

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -133,10 +133,7 @@ impl Tags {
             if let Some(header) = req_head.headers().get(tracer) {
                 if let Ok(val) = header.to_str() {
                     if !val.is_empty() {
-                        extra.insert(
-                            "header.trace".to_owned(),
-                            val.to_owned()
-                        );
+                        extra.insert("header.trace".to_owned(), val.to_owned());
                     }
                 }
             }

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -20,6 +20,8 @@ use serde_json::value::Value;
 use slog::{Key, Record, KV};
 use woothee::parser::{Parser, WootheeResult};
 
+use crate::settings::Settings;
+
 /// List of valid user-agent attributes to keep, anything not in this
 /// list is considered 'Other'. We log the user-agent on connect always
 /// to retain the full string, but for DD more tags are expensive so we
@@ -104,8 +106,8 @@ fn insert_if_not_empty(label: &str, val: &str, tags: &mut HashMap<String, String
     }
 }
 
-impl From<&RequestHead> for Tags {
-    fn from(req_head: &RequestHead) -> Self {
+impl Tags {
+    pub fn from_head(req_head: &RequestHead, settings: &Settings) -> Self {
         // Return an Option<> type because the later consumers (HandlerErrors) presume that
         // tags are optional and wrapped by an Option<> type.
         let mut tags = HashMap::new();
@@ -122,6 +124,15 @@ impl From<&RequestHead> for Tags {
                 extra.insert("ua".to_owned(), uas.to_string());
             }
         }
+        if let Some(tracer) = settings.trace_header.clone() {
+            if let Some(header) = req_head.headers().get(tracer) {
+                insert_if_not_empty(
+                    "header.trace",
+                    header.to_str().unwrap_or_default(),
+                    &mut tags,
+                );
+            }
+        }
         tags.insert("uri.method".to_owned(), req_head.method.to_string());
         // `uri.path` causes too much cardinality for influx but keep it in
         // extra for sentry
@@ -132,9 +143,10 @@ impl From<&RequestHead> for Tags {
 
 impl From<HttpRequest> for Tags {
     fn from(request: HttpRequest) -> Self {
+        let settings = Settings::from(&request);
         match request.extensions().get::<Self>() {
             Some(v) => v.clone(),
-            None => Tags::from(request.head()),
+            None => Tags::from_head(request.head(), &settings),
         }
     }
 }
@@ -249,11 +261,12 @@ impl FromRequest for Tags {
     type Future = Ready<Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
+        let settings = Settings::from(req);
         let tags = {
             let exts = req.extensions();
             match exts.get::<Tags>() {
                 Some(t) => t.clone(),
-                None => Tags::from(req.head()),
+                None => Tags::from_head(req.head(), &settings),
             }
         };
 

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -126,7 +126,7 @@ pub async fn get_tiles(
                 metrics.incr_with_tags("tiles.invalid", Some(&tags));
                 // Report directly to sentry
                 // (This is starting to become a pattern. 🤔)
-                let mut tags = Tags::from(request.head());
+                let mut tags = Tags::from_head(request.head(), &settings);
                 tags.add_extra("err", &es);
                 tags.add_tag("level", "warning");
                 l_sentry::report(&tags, sentry::event_from_error(&e));

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -107,7 +107,7 @@ where
     }
 
     fn call(&mut self, sreq: ServiceRequest) -> Self::Future {
-        let settings:&Settings = (&sreq).into();
+        let settings: &Settings = (&sreq).into();
         let mut tags = Tags::from_head(sreq.head(), settings);
         sreq.extensions_mut().insert(tags.clone());
 

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -18,6 +18,7 @@ use sentry::protocol::Event;
 use std::task::Poll;
 
 use crate::error::HandlerError;
+use crate::settings::Settings;
 use crate::tags::Tags;
 
 pub struct SentryWrapper;
@@ -106,7 +107,8 @@ where
     }
 
     fn call(&mut self, sreq: ServiceRequest) -> Self::Future {
-        let mut tags = Tags::from(sreq.head());
+        let settings = Settings::from(&sreq);
+        let mut tags = Tags::from_head(sreq.head(), &settings);
         sreq.extensions_mut().insert(tags.clone());
 
         Box::pin(self.service.call(sreq).and_then(move |mut sresp| {

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -107,8 +107,8 @@ where
     }
 
     fn call(&mut self, sreq: ServiceRequest) -> Self::Future {
-        let settings = Settings::from(&sreq);
-        let mut tags = Tags::from_head(sreq.head(), &settings);
+        let settings:&Settings = (&sreq).into();
+        let mut tags = Tags::from_head(sreq.head(), settings);
         sreq.extensions_mut().insert(tags.clone());
 
         Box::pin(self.service.call(sreq).and_then(move |mut sresp| {


### PR DESCRIPTION
## Description

This adds a `trace_header` setting. This will add the value (if found in
the Headers) to the tags as `header.trace`.

(e.g. if a request has `X-Cloud-Trace-Context: abc123` this will add a
tag with `header.trace: abc123` to the outboud tags for logging and
metrics.)
## Testing

Ensure the content of the tracing header is sent to metric and logging.

## Issue(s)

Closes #145
