### PR TITLE
feat: fill in sentry stacktraces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "regex",
  "reqwest",
  "sentry",
+ "sentry-backtrace",
  "serde 1.0.123",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = "1.0"
 # pin to 0.19 (until our onpremise is upgraded):
 # https://github.com/getsentry/sentry-rust/issues/277
 sentry = "0.19"
+sentry-backtrace = "0.19"
 serde_json = "1.0"
 sha2 = "0.9"
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_info", "dynamic-keys"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub type HandlerResult<T> = result::Result<T, HandlerError>;
 #[derive(Debug)]
 pub struct HandlerError {
     kind: HandlerErrorKind,
-    backtrace: Backtrace,
+    pub(crate) backtrace: Backtrace,
     pub tags: Tags,
 }
 
@@ -182,20 +182,7 @@ impl From<HandlerError> for HttpResponse {
 
 impl fmt::Display for HandlerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Error: {}\nTags:{:?}\nBacktrace:\n{:?}",
-            self.kind, self.tags, self.backtrace
-        )?;
-
-        // Go down the chain of errors
-        let mut error: &dyn Error = &self.kind;
-        while let Some(source) = error.source() {
-            write!(f, "\n\nCaused by: {}", source)?;
-            error = source;
-        }
-
-        Ok(())
+        self.kind.fmt(f)
     }
 }
 

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -2,10 +2,11 @@
 //!
 //! This sends [crate::error::HandlerError] events to Sentry
 
-use std::task::Context;
 use std::{
     cell::{RefCell, RefMut},
+    error::Error as StdError,
     rc::Rc,
+    task::{Context, Poll},
 };
 
 use actix_http::Extensions;
@@ -15,11 +16,8 @@ use actix_web::{
 };
 use futures::future::{self, LocalBoxFuture, TryFutureExt};
 use sentry::protocol::Event;
-use std::task::Poll;
 
-use crate::error::HandlerError;
-use crate::settings::Settings;
-use crate::tags::Tags;
+use crate::{error::HandlerError, settings::Settings, tags::Tags};
 
 pub struct SentryWrapper;
 
@@ -70,7 +68,7 @@ pub fn queue_report(mut ext: RefMut<'_, Extensions>, err: &Error) {
             return;
         }
         */
-        let event = sentry::event_from_error(herr);
+        let event = event_from_error(herr);
         if let Some(events) = ext.get_mut::<Vec<Event<'static>>>() {
             events.push(event);
         } else {
@@ -81,8 +79,7 @@ pub fn queue_report(mut ext: RefMut<'_, Extensions>, err: &Error) {
 
 /// Report an error with [crate::tags::Tags] and [Event] directly to sentry
 ///
-/// And [Event] can be derived using
-/// `sentry::event_from_error(err:Error)`
+/// And [Event] can be derived using `event_from_error(HandlerError)`
 pub fn report(tags: &Tags, mut event: Event<'static>) {
     let tags = tags.clone();
     event.tags = tags.clone().tag_tree();
@@ -164,11 +161,59 @@ where
                         }
                         */
                         tags.extend(herr.tags.clone());
-                        report(&tags, sentry::event_from_error(herr));
+                        report(&tags, event_from_error(herr));
                     }
                 }
             }
             future::ok(sresp)
         }))
+    }
+}
+
+/// Custom `sentry::event_from_error` for `HandlerError`
+///
+/// `sentry::event_from_error` can't access `std::Error` backtraces as its
+/// `backtrace()` method is currently Rust nightly only. This function works
+/// against `HandlerError` instead to access its backtrace.
+pub fn event_from_error(err: &HandlerError) -> Event<'static> {
+    let mut exceptions = vec![exception_from_error_with_backtrace(err)];
+
+    let mut source = err.source();
+    while let Some(err) = source {
+        let exception = if let Some(err) = err.downcast_ref() {
+            exception_from_error_with_backtrace(err)
+        } else {
+            exception_from_error(err)
+        };
+        exceptions.push(exception);
+        source = err.source();
+    }
+
+    exceptions.reverse();
+    Event {
+        exception: exceptions.into(),
+        level: sentry::protocol::Level::Error,
+        ..Default::default()
+    }
+}
+
+/// Custom `exception_from_error` support function for `HandlerError`
+///
+/// Based moreso on sentry_failure's `exception_from_single_fail`.
+fn exception_from_error_with_backtrace(err: &HandlerError) -> sentry::protocol::Exception {
+    let mut exception = exception_from_error(err);
+    // format the stack trace with alternate debug to get addresses
+    let bt = format!("{:#?}", err.backtrace);
+    exception.stacktrace = sentry_backtrace::parse_stacktrace(&bt);
+    exception
+}
+
+/// Exact copy of sentry's unfortunately private `exception_from_error`
+fn exception_from_error<E: StdError + ?Sized>(err: &E) -> sentry::protocol::Exception {
+    let dbg = format!("{:?}", err);
+    sentry::protocol::Exception {
+        ty: sentry::parse_type_from_debug(&dbg).to_owned(),
+        value: Some(err.to_string()),
+        ..Default::default()
     }
 }

--- a/src/web/user_agent.rs
+++ b/src/web/user_agent.rs
@@ -81,7 +81,8 @@ pub fn get_device_info(ua: &str) -> HandlerResult<(OsFamily, FormFactor)> {
     // If it's not firefox, it doesn't belong here...
     if !["firefox"].contains(&wresult.name.to_lowercase().as_str()) {
         let mut err: HandlerError = HandlerErrorKind::InvalidUA().into();
-        err.tags.add_extra("useragent", ua);
+        // XXX: Tags::from_head already adds this
+        err.tags.add_extra("ua", ua);
         err.tags
             .add_extra("name", &wresult.name.to_lowercase().as_str());
         return Err(err);
@@ -218,7 +219,7 @@ mod tests {
             HandlerErrorKind::InvalidUA() => {}
             _ => panic!("Incorrect error returned for test"),
         }
-        assert!(err.tags.extra.get("useragent") == Some(&ua_str.to_owned()));
+        assert!(err.tags.extra.get("ua") == Some(&ua_str.to_owned()));
         assert!(err.tags.extra.get("name") == Some(&"chrome".to_owned()));
         dbg!(err.tags);
     }


### PR DESCRIPTION
## Description

w/ a custom event_from_error for HandlerError

and simplify HandlerError's fmt::Display for sentry's sake

## Testing

See event improvements in sentry's UI

## Issue(s)

Closes #158
