### PR TITLE
fix: take include_regions into account for filtering 

### DIFF
--- a/src/adm/filter.rs
+++ b/src/adm/filter.rs
@@ -14,6 +14,7 @@ use super::{
 use crate::{
     error::{HandlerError, HandlerErrorKind, HandlerResult},
     metrics::Metrics,
+    server::location::LocationResult,
     tags::Tags,
     web::middleware::sentry as l_sentry,
 };
@@ -218,6 +219,7 @@ impl AdmFilter {
     pub fn filter_and_process(
         &self,
         mut tile: AdmTile,
+        location: &LocationResult,
         tags: &mut Tags,
         metrics: &Metrics,
     ) -> Option<Tile> {
@@ -233,6 +235,22 @@ impl AdmFilter {
                     .unwrap_or(&none);
                 // if the filter doesn't have anything defined, try using what's in the default.
                 // Sadly, `vec.or()` doesn't exist, so do this a bit "long hand"
+                let include_regions = if filter.include_regions.is_empty() {
+                    default
+                } else {
+                    filter
+                };
+                if !include_regions
+                    .include_regions
+                    .contains(&location.country())
+                {
+                    trace!(
+                        "Rejecting tile: region {:?} not included",
+                        location.country()
+                    );
+                    return None;
+                }
+
                 let adv_filter = if filter.advertiser_hosts.is_empty() {
                     default
                 } else {

--- a/src/adm/settings.rs
+++ b/src/adm/settings.rs
@@ -140,9 +140,9 @@ impl From<&mut Settings> for AdmSettings {
 ///     "advertiser_hosts": ["www.example.org", "example.org"],
 ///     /* Valid tile positions for this advertiser (empty for "all") */
 ///     "positions": 1,
-///     /* Valid target regions for this advertiser
-///        (use "en-US" for "all in english speaking United States") */
-///     "include_regions": ["en-US/TX", "en-US/CA"],
+///     /* Valid target countries for this advertiser
+///        TODO: could support country + subdivision, e.g. "USOK" */
+///     "include_regions": ["US", "MX"],
 ///     /* Allowed hosts for impression URLs.
 ///        Empty means to use the impression URLs in "DEFAULT" */
 ///     "impression_hosts: [],

--- a/src/adm/settings.rs
+++ b/src/adm/settings.rs
@@ -126,7 +126,18 @@ impl From<&mut Settings> for AdmSettings {
                 return serde_json::from_reader(f).expect("Invalid ADM Settings file");
             }
         }
-        serde_json::from_str(&settings.adm_settings).expect("Invalid ADM Settings JSON string")
+        let adm_settings: AdmSettings =
+            serde_json::from_str(&settings.adm_settings).expect("Invalid ADM Settings JSON string");
+        for (adv, filter_setting) in &adm_settings {
+            if filter_setting
+                .include_regions
+                .iter()
+                .any(|region| region != &region.to_uppercase())
+            {
+                panic!("Advertiser {:?} include_regions must be uppercase", adv);
+            }
+        }
+        adm_settings
     }
 }
 

--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -177,7 +177,11 @@ pub async fn get_tiles(
     let tiles = response
         .tiles
         .into_iter()
-        .filter_map(|tile| state.filter.filter_and_process(tile, tags, metrics))
+        .filter_map(|tile| {
+            state
+                .filter
+                .filter_and_process(tile, location, tags, metrics)
+        })
         .take(settings.adm_max_tiles as usize)
         .collect();
     Ok(TileResponse { tiles })

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -63,7 +63,7 @@ pub struct Settings {
     pub adm_sub1: Option<String>,
     /// adm Endpoint URL
     pub adm_endpoint_url: String,
-    /// max tiles to accept from ADM (default: 2)
+    /// max number of tiles returned to clients (default: 2)
     pub adm_max_tiles: u8,
     /// number of tiles to query from ADM (default: 10)
     pub adm_query_tile_count: u8,


### PR DESCRIPTION
## Description

some test cleanup: don't filter out the default "Dunder Mifflin" tile (its
impression host was previously invalid)

## Testing

New lightweight integration test passes

## Issue(s)

Closes #216
