### PR TITLE
feat: Switch hasher to blake3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,10 +314,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 
 [[package]]
 name = "async-trait"
@@ -417,6 +429,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "blake3"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcd555c66291d5f836dbb6883b48660ece810fe25a31f3bdfb911945dff2691f"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.1",
+ "cc",
+ "cfg-if 1.0.0",
+ "constant_time_eq",
+ "digest",
 ]
 
 [[package]]
@@ -579,6 +605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "contile"
 version = "0.4.1"
 dependencies = [
@@ -588,6 +620,7 @@ dependencies = [
  "actix-web",
  "backtrace",
  "base64 0.13.0",
+ "blake3",
  "bytes 1.0.1",
  "cadence",
  "chrono",
@@ -1375,7 +1408,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "bitflags",
  "cfg-if 1.0.0",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ actix-rt = "1"  # 2+ breaks testing, May need actix-web 4+?
 actix-web = "3"
 backtrace = "0.3"
 base64 = "0.13"
+blake3 = "1.0"
 bytes = "1.0"
 cadence = "0.26"
 chrono = "0.4"

--- a/src/server/img_storage.rs
+++ b/src/server/img_storage.rs
@@ -1,11 +1,5 @@
 //! Fetch and store a given remote image into Google Storage for CDN caching
-use std::{
-    collections::hash_map::DefaultHasher,
-    env,
-    hash::{Hash, Hasher},
-    io::Cursor,
-    time::Duration,
-};
+use std::{env, io::Cursor, time::Duration};
 
 use actix_http::http::HeaderValue;
 use actix_web::http::uri;
@@ -286,9 +280,7 @@ impl StoreImage {
 
     /// Generate a unique hash based on the content of the image
     pub fn as_hash(&self, source: &Bytes) -> String {
-        let mut hasher = DefaultHasher::new();
-        source.hash(&mut hasher);
-        base64::encode_config(hasher.finish().to_ne_bytes(), base64::URL_SAFE_NO_PAD)
+        base64::encode_config(blake3::hash(source).as_bytes(), base64::URL_SAFE_NO_PAD)
     }
 
     /// Fetch the bytes for an image based on a URI


### PR DESCRIPTION
## Description

Switch from default rust hasher to Blake3

## Testing

No functional change should happen. You can use the built in unit test by specifying:
```
GOOGLE_APPLICATION_CREDENTIALS=/PathToYourCredentials.json \
CONTILE_TEST_PROJECT=project-name-here \
CONTILE_TEST_BUCKET=bucket-name-here \
cargo test
```

## Issue(s)

Closes #228.
