### PR TITLE
feat: Add local server hostname to tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
  "dashmap",
  "docopt",
  "futures",
+ "gethostname",
  "hex",
  "hostname",
  "image",
@@ -1084,6 +1085,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,11 +1479,12 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "maxminddb"
-version = "0.17.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13fa57adcc4f3aca91e511b3cdaa58ed8cbcbf97f20e342a11218c76e127f51"
+checksum = "5a2af4902d7569c441449f2315cb83598917b13275209529103e10c238fcf3db"
 dependencies = [
  "log",
+ "memchr",
  "serde 1.0.126",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,13 @@ cloud-storage = "0.6" # 0.7+ includes request 0.11, tokio 1.4
 config = "0.11"
 dashmap = "4.0.2"
 futures = "0.3"
+gethostname = "0.2.1"
 hex = "0.4"
 hostname = "0.3"
 image = "0.23"
 lazy_static = "1.4"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
-maxminddb = "0.17"
+maxminddb = "0.21"
 rand ="0.8"
 regex = "1.4"
 reqwest = { version = "0.10", features = ["json"] } # 0.11+ conflicts with actix & tokio. Block until actix-web 4+?

--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -144,6 +144,15 @@ pub async fn get_tiles(
     .map_err(|e| HandlerError::internal(&e.to_string()))?;
     let adm_url = adm_url.as_str();
 
+    // To reduce cardinality, only add this tag when fetching data from
+    // the partner. (This tag is only for metrics.)
+    tags.add_metric(
+        "srv.hostname",
+        &gethostname::gethostname()
+            .into_string()
+            .unwrap_or_else(|_| "Unkwnown".to_owned()),
+    );
+
     info!("adm::get_tiles GET {}", adm_url);
     metrics.incr("tiles.adm.request");
     let response: AdmTileResponse = if state.settings.test_mode {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -235,7 +235,6 @@ mod tests {
     fn test_tags() {
         use actix_web::dev::RequestHead;
         use actix_web::http::{header, uri::Uri};
-        use std::collections::HashMap;
 
         let mut rh = RequestHead::default();
         let settings = Settings::default();
@@ -250,13 +249,11 @@ mod tests {
 
         let tags = Tags::from_head(&rh, &settings);
 
-        let mut result = HashMap::<String, String>::new();
-        result.insert("ua.os.ver".to_owned(), "NT 10.0".to_owned());
-        result.insert("ua.os.family".to_owned(), "Windows".to_owned());
-        result.insert("ua.browser.ver".to_owned(), "72.0".to_owned());
-        result.insert("uri.method".to_owned(), "GET".to_owned());
-
-        assert_eq!(tags.tags, result)
+        assert_eq!(tags.tags.get("ua.os.ver"), Some(&"NT 10.0".to_owned()));
+        assert_eq!(tags.tags.get("ua.os.family"), Some(&"Windows".to_owned()));
+        assert_eq!(tags.tags.get("ua.browser.ver"), Some(&"72.0".to_owned()));
+        assert_eq!(tags.tags.get("uri.method"), Some(&"GET".to_owned()));
+        assert!(tags.tags.get("srv.hostname").is_some())
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -179,6 +179,12 @@ impl Metrics {
                     tagged = tagged.with_tag(key, val.as_ref());
                 }
             }
+            // mix in the metric only tags.
+            for key in mtags.metric.keys().clone() {
+                if let Some(val) = mtags.metric.get(key) {
+                    tagged = tagged.with_tag(key, val.as_ref())
+                }
+            }
             // Include any "hard coded" tags.
             // incr = incr.with_tag("version", env!("CARGO_PKG_VERSION"));
             match tagged.try_send() {
@@ -253,7 +259,6 @@ mod tests {
         assert_eq!(tags.tags.get("ua.os.family"), Some(&"Windows".to_owned()));
         assert_eq!(tags.tags.get("ua.browser.ver"), Some(&"72.0".to_owned()));
         assert_eq!(tags.tags.get("uri.method"), Some(&"GET".to_owned()));
-        assert!(tags.tags.get("srv.hostname").is_some())
     }
 
     #[test]

--- a/src/server/cache.rs
+++ b/src/server/cache.rs
@@ -40,7 +40,7 @@ impl TilesCache {
         let metrics = Metrics::from(&metrics);
         actix_rt::spawn(async move {
             loop {
-                tiles_cache_periodic_reporter(&cache, &metrics).await;
+                tiles_cache_garbage_collect(&cache, &metrics).await;
                 actix_rt::time::delay_for(interval).await;
             }
         });
@@ -102,8 +102,8 @@ impl TilesContent {
     }
 }
 
-async fn tiles_cache_periodic_reporter(cache: &TilesCache, metrics: &Metrics) {
-    trace!("tiles_cache_periodic_reporter");
+async fn tiles_cache_garbage_collect(cache: &TilesCache, metrics: &Metrics) {
+    trace!("tiles_cache_garbage_collect");
     // calculate the size and GC (for seldomly used Tiles) while we're at it
     let mut cache_count = 0;
     let mut cache_size = 0;

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -147,7 +147,11 @@ impl Tags {
         // `uri.path` causes too much cardinality for influx but keep it in
         // extra for sentry
         extra.insert("uri.path".to_owned(), req_head.uri.to_string());
-        Tags { tags, extra, metric: HashMap::new() }
+        Tags {
+            tags,
+            extra,
+            metric: HashMap::new(),
+        }
     }
 }
 

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -126,6 +126,13 @@ impl Tags {
                 insert_if_not_empty("ua.os.family", metrics_os, &mut tags);
                 insert_if_not_empty("ua.os.ver", &ua_result.os_version.to_owned(), &mut tags);
                 insert_if_not_empty("ua.browser.ver", ua_result.version, &mut tags);
+                insert_if_not_empty(
+                    "srv.hostname",
+                    &gethostname::gethostname()
+                        .into_string()
+                        .unwrap_or_else(|_| "Unkwnown".to_owned()),
+                    &mut tags,
+                );
                 extra.insert("ua".to_owned(), uas.to_string());
             }
         }


### PR DESCRIPTION
## Description

Adds the local server hostname to the metric and logging tags. 

## Testing

Unit test modified to include check for presence. 

## Issue(s)

Closes #200
