### PR TITLE
fix: Write version.json before docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,6 @@ jobs:
     steps:
       - checkout
       - setup-rust
-      - write-version
       - cargo-build
       - run-tests
 
@@ -138,6 +137,7 @@ jobs:
               fi
       #- save-sccache-cache
       - checkout
+      - write-version
       - run:
           name: Build Docker image
           command: docker build -t app:build .


### PR DESCRIPTION
In bc8d5f29e406f57cfbbae533ee5cbd21cd49e38e the step to write version.json was moved from build to test. This meant that the default version.json in the repository was written to the docker image. Because the default version.json doesn't have a `BUILD_URL` defined, Jenkins has not been deploying contile
