### PR TITLE
Block deploy CI job on integration-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,7 @@ workflows:
           requires:
             - build
             - test
+            - contile-integration-tests
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
## Description

Currently the `deploy` CI job only requires the `build` and `test` jobs. This pull request ensures that an integration test failure blocks the deployment.

## Testing

Submit a pull request that causes an integration-test failure and verify that CircleCI does **not** run the `deploy` job.

## Issue(s)

Resolve #238
