### PR TITLE
Upgrade the Docker images for contile-integration-tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   partner:
-    image: mozilla/contile-integration-tests-partner:21.2.0
+    image: mozilla/contile-integration-tests-partner:21.3.0
     container_name: partner
     environment:
       PORT: 5000
@@ -44,7 +44,7 @@ services:
     #entrypoint: >
     #  /bin/sh -c "hostname -I && bin/contile"
   client:
-    image: mozilla/contile-integration-tests-client:21.2.0
+    image: mozilla/contile-integration-tests-client:21.3.0
     container_name: client
     depends_on:
       - partner


### PR DESCRIPTION
## Description

The **21.3.0** release changes the response for invalid query parameter values to a `400 Bad Request`, adds validation to the `sub2` and `country-code` query parameters, and improves the error reporting for integration test failures by including the response content in the error message for unexpected response status codes.

See https://github.com/mozilla-services/contile-integration-tests/releases/tag/21.3.0

## Testing

Verify that new pull requests use the new Docker images.

## Issue(s)

NA
