### PR TITLE
feat: add conditional load handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,8 +557,6 @@ dependencies = [
 [[package]]
 name = "cloud-storage"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a80e16e48e19ebaa0186530f7f31bb4cd6b9e3e0bbf55272845b05aac8825f"
 dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
@@ -581,6 +579,16 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "combine"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d47c1b11006b87e492b53b313bb699ce60e16613c4dddaa91f8f7c220ab2fa"
+dependencies = [
+ "bytes 1.0.1",
+ "memchr",
+]
 
 [[package]]
 name = "config"
@@ -636,6 +644,7 @@ dependencies = [
  "log",
  "maxminddb",
  "rand 0.8.4",
+ "redis",
  "regex",
  "reqwest",
  "sentry",
@@ -852,6 +861,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -2015,6 +2030,21 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "redis"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bbc1838d8d0b423f325d6fac80c5f19109c7d16c8c37c584893dc17cf71c63d"
+dependencies = [
+ "async-trait",
+ "combine",
+ "dtoa",
+ "itoa",
+ "percent-encoding",
+ "sha1",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bytes = "1.0"
 cadence = "0.26"
 chrono = "0.4"
 docopt = "1.1"
-cloud-storage = "0.6" # 0.7+ includes request 0.11, tokio 1.4
+cloud-storage = {path = "vendor/cloud-storage-rs"}  # 0.7+ includes request 0.11, tokio 1.4
 config = "0.11"
 dashmap = "4.0.2"
 futures = "0.3"
@@ -38,6 +38,7 @@ log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"
 maxminddb = "0.17"
 rand ="0.8"
 regex = "1.4"
+redis = "0.21"
 reqwest = { version = "0.10", features = ["json"] } # 0.11+ conflicts with actix & tokio. Block until actix-web 4+?
 serde = "1.0"
 # pin to 0.19 (until our onpremise is upgraded):

--- a/src/server/img_storage.rs
+++ b/src/server/img_storage.rs
@@ -438,10 +438,12 @@ mod tests {
         // sometimes the IDE doesn't include the host env vars.
         // this lets you set them proactively.
 
+        /*
         std::env::set_var(
             "GOOGLE_APPLICATION_CREDENTIALS",
             "/home/jrconlin/.ssh/keys/sync-spanner-dev.json",
         );
+        // */
     }
 
     fn test_storage_settings() -> StorageSettings {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -19,6 +19,7 @@ use crate::{
 pub mod cache;
 pub mod img_storage;
 pub mod location;
+pub mod remote_cache;
 
 /// Arbitrary initial cache size based on the expected mean, feel free to
 /// adjust
@@ -97,7 +98,7 @@ impl Server {
         let req = reqwest::Client::builder()
             .user_agent(REQWEST_USER_AGENT)
             .build()?;
-        let img_store = StoreImage::create(&settings, &req).await?;
+        let img_store = StoreImage::connect(&settings, &req).await?;
         let state = ServerState {
             metrics: Box::new(metrics.clone()),
             adm_endpoint_url: settings.adm_endpoint_url.clone(),

--- a/src/server/remote_cache.rs
+++ b/src/server/remote_cache.rs
@@ -1,0 +1,73 @@
+use redis::Commands;
+use serde::{Deserialize, Serialize};
+use serde_json::{from_str, json};
+
+use crate::error::{HandlerError, HandlerResult};
+use crate::settings::Settings;
+
+#[derive(Clone, Debug)]
+pub struct RemoteImageCache {
+    client: redis::Client,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum CacheState {
+    Pending,
+    Available,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CacheValue {
+    pub state: CacheState,
+    pub data: Option<String>,
+}
+
+impl RemoteImageCache {
+    pub fn new(settings: &Settings) -> HandlerResult<Self> {
+        let client = redis::Client::open(settings.redis_server.clone())
+            .map_err(|e| HandlerError::internal(&e.to_string()))?;
+        Ok(Self { client })
+    }
+
+    pub fn put(self, key: &str, value: CacheValue) -> HandlerResult<()> {
+        let mut conn = self
+            .client
+            .get_connection()
+            .map_err(|e| HandlerError::internal(&e.to_string()))?;
+        conn.set(key, json!(value).to_string())
+            .map_err(|e| HandlerError::internal(&e.to_string()))?;
+        Ok(())
+    }
+
+    pub fn get(self, key: &str) -> HandlerResult<Option<CacheValue>> {
+        let mut conn = self
+            .client
+            .get_connection()
+            .map_err(|e| HandlerError::internal(&e.to_string()))?;
+        let result: String = match conn.get(key) {
+            Ok(v) => v,
+            Err(e) => {
+                dbg!(e);
+                "".to_owned()
+            }
+        };
+        if result.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(from_str::<CacheValue>(&result).map_err(|e| {
+            HandlerError::internal(&format!(
+                "Could not deserialize shared cache entry: {} {:?}",
+                key, e
+            ))
+        })?))
+    }
+
+    pub fn del(self, key: &str) -> HandlerResult<()> {
+        let mut conn = self
+            .client
+            .get_connection()
+            .map_err(|e| HandlerError::internal(&e.to_string()))?;
+        conn.del(key)
+            .map_err(|e| HandlerError::internal(&e.to_string()))
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -79,12 +79,14 @@ pub struct Settings {
     pub adm_ignore_advertisers: Option<String>,
     /// a JSON list of advertisers to allow for versions of firefox less than 91.
     pub adm_has_legacy_image: Option<String>,
+    /// Percentage of overall time for fetch "jitter".
+    pub jitter: u8,
+    /// URL to redis server
+    pub redis_server: String,
 
     // OBSOLETE:
     pub sub1: Option<String>,
     pub partner_id: Option<String>,
-    /// Percentage of overall time for fetch "jitter".
-    pub jitter: u8,
 }
 
 impl Default for Settings {
@@ -120,10 +122,11 @@ impl Default for Settings {
             adm_has_legacy_image: Some(
                 r#"["adidas","amazon","ebay","etsy","geico","nike","samsung","wix"]"#.to_owned(),
             ),
-            sub1: Some("demofeed".to_owned()),
-            partner_id: Some("123456789".to_owned()),
             // +/- 10% of time for jitter.
             jitter: 10,
+            redis_server: "redis://127.0.0.1:6379".to_owned(),
+            sub1: Some("demofeed".to_owned()),
+            partner_id: Some("123456789".to_owned()),
         }
     }
 }

--- a/vendor/cloud-storage-rs/CHANGELOG.md
+++ b/vendor/cloud-storage-rs/CHANGELOG.md
@@ -1,0 +1,9 @@
+# 0.9
+Refactor the library away from having a single global client, but provide a client of our own that
+the user of the library is responsible for. This means that the user has control over the allocation
+and destruction of the client. This solves issue #60 and is enabled due to tireless work by
+shepmaster. Big thanks!
+
+# 0.10
+Small fix to the public interface of `sync::ObjectClient` that was not properly sync.
+Update cloud storage to use the new url, `www.googleapis.com` => `storage.googleapis.com`

--- a/vendor/cloud-storage-rs/Cargo.toml
+++ b/vendor/cloud-storage-rs/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "cloud-storage"
+version = "0.6.2"
+authors = ["Luuk Wester <luuk.wester@gmail.com>"]
+edition = "2018"
+description = "A crate for uploading files to Google cloud storage, and for generating download urls."
+license = "MIT"
+repository = "https://github.com/ThouCheese/cloud-storage-rs"
+documentation = "https://docs.rs/cloud-storage"
+keywords = ["google", "cloud", "storage"]
+readme = "README.md"
+categories = ["api-bindings", "web-programming"]
+# maintenance = { status = "actively-developed" }
+
+[features]
+default = ["native-tls"]
+
+sync = ["reqwest/blocking"]
+native-tls = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+trust-dns = ["reqwest/trust-dns"]
+
+[dependencies]
+reqwest =          { version = "0.10", default-features = false, features = ["json", "stream"] }
+percent-encoding = { version = "2",    default-features = false }
+jsonwebtoken =     { version = "7",    default-features = false }
+serde =            { version = "1",    default-features = false, features = ["derive"] }
+serde_json =       { version = "1",    default-features = false }
+base64 =           { version = "0.12", default-features = false }
+lazy_static =      { version = "1",    default-features = false }
+dotenv =           { version = "0.15", default-features = false }
+openssl =          { version = "0.10", default-features = false }
+chrono =           { version = "0.4",  default-features = false, features = ["serde"] }
+hex =              { version = "0.4",  default-features = false, features = ["alloc"] }
+tokio =            { version = "0.2",  default-features = false, features = ["macros", "rt-threaded"] }
+futures =          { version = "0.3",  default_features = false }
+bytes =            { version = "0.5",  default_features = false }
+
+[package.metadata.docs.rs]
+features = ["sync"]

--- a/vendor/cloud-storage-rs/LICENSE
+++ b/vendor/cloud-storage-rs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Luuk Wester
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/cloud-storage-rs/README.md
+++ b/vendor/cloud-storage-rs/README.md
@@ -1,0 +1,42 @@
+# Cloud Storage
+
+[![cloud-storage-rs on crates.io](https://img.shields.io/crates/v/cloud-storage.svg)](https://crates.io/crates/cloud-storage)
+[![stripe-rust on docs.rs](https://docs.rs/cloud-storage/badge.svg)](https://docs.rs/cloud-storage)
+
+A library that can be used to push blobs to [Google Cloud Storage](https://cloud.google.com/storage/), and then generate download links to those files.
+### Usage
+Add the following line to you Cargo.toml
+```toml
+[dependencies]
+cloud-storage = "0.6"
+```
+### Examples
+```rust
+// create a new Bucket
+let new_bucket = NewBucket { name: "mybucket", ..Default::default() }
+let bucket = Bucket::create(new_bucket).await?;
+// upload a file to our new bucket
+let content = b"Your file is now on google cloud storage!";
+bucket.upload(content, "folder/filename.txt", "application/text").await?;
+let mut object = Object::create("mybucket", content, "folder/filename.txt", "application/text").await?;
+// let's copy the file
+object.copy("mybucket2: electric boogaloo", "otherfolder/filename.txt").await?;
+// print a link to the file
+println!("{}", object.download_url(1000)); // download link for 1000 seconds
+// remove the file from the bucket
+object.delete().await?;
+```
+
+Authorization can be granted using the `SERVICE_ACCOUNT` environment variable, which should contain path to the `service-account-*******.json` file that contains the Google credentials. The service account requires the permission `devstorage.full_control`. This is not strictly necessary, so if you need this fixed, let me know! 
+
+The service account should also have the roles `Service Account Token Creator` (for generating access tokens) and `Storage Object Admin` (for generating sign urls to download the files).
+
+### Sync
+If you're not (yet) interested in running an async executor, then `cloud_storage` exposes a sync api. To use it, enable the feature flag `sync`, and then call instead of calling `function().await`, call `function_sync()`.
+
+### Testing
+To run the tests for this project, first create an enviroment parameter (or entry in the .env file) named TEST_BUCKET. Make sure that this name is not already in use! The tests will create this bucket for its testing purposes. It will also create a couple of other buckets with this name as prefix, but these will be deleted again. Next, you will need a Google Cloud Storage project, for which you must create a service account. Download the service-account.json file and place the path to the file in the `SERVICE_ACCOUNT` environment parameter. Then, run
+```bash
+cargo test --tests --features=sync -- --test-threads=1
+```
+The `test-threads=1` is necessary so that the tests don't exceed the 2 per second bucket creating rate limit. (Depending on your internet speed, you may be able to use more than 1 test thread)

--- a/vendor/cloud-storage-rs/src/client.rs
+++ b/vendor/cloud-storage-rs/src/client.rs
@@ -1,0 +1,96 @@
+//! Clients for Google Cloud Storage endpoints.
+
+use std::fmt;
+use tokio::sync::Mutex;
+
+use crate::token::Token;
+
+mod bucket;
+mod bucket_access_control;
+mod default_object_access_control;
+mod hmac_key;
+mod object;
+mod object_access_control;
+
+pub use bucket::BucketClient;
+pub use bucket_access_control::BucketAccessControlClient;
+pub use default_object_access_control::DefaultObjectAccessControlClient;
+pub use hmac_key::HmacKeyClient;
+pub use object::ObjectClient;
+pub use object_access_control::ObjectAccessControlClient;
+
+/// The primary entrypoint to perform operations with Google Cloud Storage.
+pub struct Client {
+    client: reqwest::Client,
+
+    /// Static `Token` struct that caches
+    token_cache: Mutex<Token>,
+}
+
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Client")
+            .field("client", &self.client)
+            .field("token_cache", &"<opaque>")
+            .finish()
+    }
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self {
+            client: Default::default(),
+            token_cache: Mutex::new(Token::new(
+                "https://www.googleapis.com/auth/devstorage.full_control",
+            )),
+        }
+    }
+}
+
+impl Client {
+    /// Constructs a client
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Operations on [`Bucket`](crate::bucket::Bucket)s.
+    pub fn bucket(&self) -> BucketClient<'_> {
+        BucketClient(self)
+    }
+
+    /// Operations on [`BucketAccessControl`](crate::bucket_access_control::BucketAccessControl)s.
+    pub fn bucket_access_control(&self) -> BucketAccessControlClient<'_> {
+        BucketAccessControlClient(self)
+    }
+
+    /// Operations on [`DefaultObjectAccessControl`](crate::default_object_access_control::DefaultObjectAccessControl)s.
+    pub fn default_object_access_control(&self) -> DefaultObjectAccessControlClient<'_> {
+        DefaultObjectAccessControlClient(self)
+    }
+
+    /// Operations on [`HmacKey`](crate::hmac_key::HmacKey)s.
+    pub fn hmac_key(&self) -> HmacKeyClient<'_> {
+        HmacKeyClient(self)
+    }
+
+    /// Operations on [`Object`](crate::object::Object)s.
+    pub fn object(&self) -> ObjectClient<'_> {
+        ObjectClient(self)
+    }
+
+    /// Operations on [`ObjectAccessControl`](crate::object_access_control::ObjectAccessControl)s.
+    pub fn object_access_control(&self) -> ObjectAccessControlClient<'_> {
+        ObjectAccessControlClient(self)
+    }
+
+    async fn get_headers(&self) -> crate::Result<reqwest::header::HeaderMap> {
+        let mut result = reqwest::header::HeaderMap::new();
+        let mut guard = self.token_cache.lock().await;
+        let token = guard.get(&self.client).await?;
+        result.insert(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", token).parse().unwrap(),
+        );
+        Ok(result)
+    }
+}

--- a/vendor/cloud-storage-rs/src/client/bucket.rs
+++ b/vendor/cloud-storage-rs/src/client/bucket.rs
@@ -1,0 +1,361 @@
+use crate::{
+    bucket::{IamPolicy, TestIamPermission},
+    object::percent_encode,
+    error::GoogleResponse,
+    resources::common::ListResponse,
+    Bucket, NewBucket,
+};
+
+/// Operations on [`Bucket`]()s.
+#[derive(Debug)]
+pub struct BucketClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> BucketClient<'a> {
+    /// Creates a new `Bucket`. There are many options that you can provide for creating a new
+    /// bucket, so the `NewBucket` resource contains all of them. Note that `NewBucket` implements
+    /// `Default`, so you don't have to specify the fields you're not using. And error is returned
+    /// if that bucket name is already taken.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket::{Bucket, NewBucket};
+    /// use cloud_storage::bucket::{Location, MultiRegion};
+    ///
+    /// let client = Client::default();
+    /// let new_bucket = NewBucket {
+    ///    name: "cloud-storage-rs-doc-1".to_string(), // this is the only mandatory field
+    ///    location: Location::Multi(MultiRegion::Eu),
+    ///    ..Default::default()
+    /// };
+    /// let bucket = client.bucket().create(&new_bucket).await?;
+    /// # client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(&self, new_bucket: &NewBucket) -> crate::Result<Bucket> {
+        let url = format!("{}/b/", crate::BASE_URL);
+        let project = &crate::SERVICE_ACCOUNT.project_id;
+        let query = [("project", project)];
+        let result: GoogleResponse<Bucket> = self
+            .0
+            .client
+            .post(&url)
+            .headers(self.0.get_headers().await?)
+            .query(&query)
+            .json(new_bucket)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Returns all `Bucket`s within this project.
+    ///
+    /// ### Note
+    /// When using incorrect permissions, this function fails silently and returns an empty list.
+    ///
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::default();
+    /// let buckets = client.bucket().list().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self) -> crate::Result<Vec<Bucket>> {
+        let url = format!("{}/b/", crate::BASE_URL);
+        let project = &crate::SERVICE_ACCOUNT.project_id;
+        let query = [("project", project)];
+        let result: GoogleResponse<ListResponse<Bucket>> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .query(&query)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.items),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Returns a single `Bucket` by its name. If the Bucket does not exist, an error is returned.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::default();
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-2".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket).await?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-2").await?;
+    /// # client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(&self, name: &str) -> crate::Result<Bucket> {
+        let url = format!(
+            "{}/b/{}",
+            crate::BASE_URL,
+            percent_encode(name),
+        );
+        let result: GoogleResponse<Bucket> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Update an existing `Bucket`. If you declare you bucket as mutable, you can edit its fields.
+    /// You can then flush your changes to Google Cloud Storage using this method.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket::{Bucket, RetentionPolicy};
+    ///
+    /// let client = Client::default();
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-3".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket).await?;
+    ///
+    /// let mut bucket = client.bucket().read("cloud-storage-rs-doc-3").await?;
+    /// bucket.retention_policy = Some(RetentionPolicy {
+    ///     retention_period: 50,
+    ///     effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+    ///     is_locked: Some(false),
+    /// });
+    /// client.bucket().update(&bucket).await?;
+    /// # client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(&self, bucket: &Bucket) -> crate::Result<Bucket> {
+        let url = format!(
+            "{}/b/{}",
+            crate::BASE_URL,
+            percent_encode(&bucket.name),
+        );
+        let result: GoogleResponse<Bucket> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(bucket)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Delete an existing `Bucket`. This permanently removes a bucket from Google Cloud Storage.
+    /// An error is returned when you don't have sufficient permissions, or when the
+    /// `retention_policy` prevents you from deleting your Bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::default();
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "unnecessary-bucket".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket).await?;
+    ///
+    /// let bucket = client.bucket().read("unnecessary-bucket").await?;
+    /// client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(&self, bucket: Bucket) -> crate::Result<()> {
+        let url = format!("{}/b/{}", crate::BASE_URL, percent_encode(&bucket.name));
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+
+    /// Returns the [IAM Policy](https://cloud.google.com/iam/docs/) for this bucket.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::default();
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-4".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket).await?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-4").await?;
+    /// let policy = client.bucket().get_iam_policy(&bucket).await?;
+    /// # client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_iam_policy(&self, bucket: &Bucket) -> crate::Result<IamPolicy> {
+        let url = format!("{}/b/{}/iam", crate::BASE_URL, percent_encode(&bucket.name));
+        let result: GoogleResponse<IamPolicy> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Updates the [IAM Policy](https://cloud.google.com/iam/docs/) for this bucket.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    /// use cloud_storage::bucket::{IamPolicy, Binding, IamRole, StandardIamRole, Entity};
+    ///
+    /// let client = Client::default();
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-5".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket).await?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-5").await?;
+    /// let iam_policy = IamPolicy {
+    ///     version: 1,
+    ///     bindings: vec![
+    ///         Binding {
+    ///             role: IamRole::Standard(StandardIamRole::ObjectViewer),
+    ///             members: vec!["allUsers".to_string()],
+    ///             condition: None,
+    ///         }
+    ///     ],
+    ///     ..Default::default()
+    /// };
+    /// let policy = client.bucket().set_iam_policy(&bucket, &iam_policy).await?;
+    /// # client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn set_iam_policy(
+        &self,
+        bucket: &Bucket,
+        iam: &IamPolicy,
+    ) -> crate::Result<IamPolicy> {
+        let url = format!("{}/b/{}/iam", crate::BASE_URL, percent_encode(&bucket.name));
+        let result: GoogleResponse<IamPolicy> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(iam)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Checks whether the user provided in the service account has this permission.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::default();
+    /// let bucket = client.bucket().read("my-bucket").await?;
+    /// client.bucket().test_iam_permission(&bucket, "storage.buckets.get").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn test_iam_permission(
+        &self,
+        bucket: &Bucket,
+        permission: &str,
+    ) -> crate::Result<TestIamPermission> {
+        if permission == "storage.buckets.list" || permission == "storage.buckets.create" {
+            return Err(crate::Error::new(
+                "tested permission must not be `storage.buckets.list` or `storage.buckets.create`",
+            ));
+        }
+        let url = format!("{}/b/{}/iam/testPermissions", crate::BASE_URL, percent_encode(&bucket.name));
+        let result: GoogleResponse<TestIamPermission> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .query(&[("permissions", permission)])
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/client/bucket_access_control.rs
+++ b/vendor/cloud-storage-rs/src/client/bucket_access_control.rs
@@ -1,0 +1,218 @@
+use crate::{
+    bucket_access_control::{BucketAccessControl, Entity, NewBucketAccessControl},
+    object::percent_encode,
+    error::GoogleResponse,
+    resources::common::ListResponse,
+};
+
+/// Operations on [`BucketAccessControl`](BucketAccessControl)s.
+#[derive(Debug)]
+pub struct BucketAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> BucketAccessControlClient<'a> {
+    /// Create a new `BucketAccessControl` using the provided `NewBucketAccessControl`, related to
+    /// the `Bucket` provided by the `bucket_name` argument.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, NewBucketAccessControl};
+    /// use cloud_storage::bucket_access_control::{Role, Entity};
+    ///
+    /// let client = Client::default();
+    /// let new_bucket_access_control = NewBucketAccessControl {
+    ///     entity: Entity::AllUsers,
+    ///     role: Role::Reader,
+    /// };
+    /// client.bucket_access_control().create("mybucket", &new_bucket_access_control).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(
+        &self,
+        bucket: &str,
+        new_bucket_access_control: &NewBucketAccessControl,
+    ) -> crate::Result<BucketAccessControl> {
+        let url = dbg!(format!(
+            "{}/b/{}/acl",
+            crate::BASE_URL,
+            percent_encode(bucket),
+        ));
+        let result: GoogleResponse<BucketAccessControl> = self
+            .0
+            .client
+            .post(&url)
+            .headers(self.0.get_headers().await?)
+            .json(new_bucket_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Returns all `BucketAccessControl`s related to this bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket_access_control::BucketAccessControl;
+    ///
+    /// let client = Client::default();
+    /// let acls = client.bucket_access_control().list("mybucket").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self, bucket: &str) -> crate::Result<Vec<BucketAccessControl>> {
+        let url = format!("{}/b/{}/acl", crate::BASE_URL, percent_encode(bucket));
+        let result: GoogleResponse<ListResponse<BucketAccessControl>> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.items),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Returns the ACL entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let controls = client.bucket_access_control().read("mybucket", &Entity::AllUsers).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(&self, bucket: &str, entity: &Entity) -> crate::Result<BucketAccessControl> {
+        let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, percent_encode(bucket), percent_encode(&entity.to_string()));
+        let result: GoogleResponse<BucketAccessControl> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Update this `BucketAccessControl`.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let mut acl = client.bucket_access_control().read("mybucket", &Entity::AllUsers).await?;
+    /// acl.entity = Entity::AllAuthenticatedUsers;
+    /// client.bucket_access_control().update(&acl).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(
+        &self,
+        bucket_access_control: &BucketAccessControl,
+    ) -> crate::Result<BucketAccessControl> {
+        let url = format!(
+            "{}/b/{}/acl/{}",
+            crate::BASE_URL,
+            percent_encode(&bucket_access_control.bucket),
+            percent_encode(&bucket_access_control.entity.to_string()),
+        );
+        let result: GoogleResponse<BucketAccessControl> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(bucket_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Permanently deletes the ACL entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let controls = client.bucket_access_control().read("mybucket", &Entity::AllUsers).await?;
+    /// client.bucket_access_control().delete(controls).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(&self, bucket_access_control: BucketAccessControl) -> crate::Result<()> {
+        let url = format!(
+            "{}/b/{}/acl/{}",
+            crate::BASE_URL,
+            percent_encode(&bucket_access_control.bucket),
+            percent_encode(&bucket_access_control.entity.to_string()),
+        );
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/client/default_object_access_control.rs
+++ b/vendor/cloud-storage-rs/src/client/default_object_access_control.rs
@@ -1,0 +1,243 @@
+use crate::{
+    bucket_access_control::Entity,
+    object::percent_encode,
+    default_object_access_control::{DefaultObjectAccessControl, NewDefaultObjectAccessControl},
+    error::GoogleResponse,
+    resources::common::ListResponse,
+};
+
+/// Operations on [`DefaultObjectAccessControl`](DefaultObjectAccessControl)s.
+#[derive(Debug)]
+pub struct DefaultObjectAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> DefaultObjectAccessControlClient<'a> {
+    /// Create a new `DefaultObjectAccessControl` entry on the specified bucket.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::default_object_access_control::{
+    ///     DefaultObjectAccessControl, NewDefaultObjectAccessControl, Role, Entity,
+    /// };
+    ///
+    /// let client = Client::default();
+    /// let new_acl = NewDefaultObjectAccessControl {
+    ///     entity: Entity::AllAuthenticatedUsers,
+    ///     role: Role::Reader,
+    /// };
+    /// let default_acl = client.default_object_access_control().create("mybucket", &new_acl).await?;
+    /// # client.default_object_access_control().delete(default_acl).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(
+        &self,
+        bucket: &str,
+        new_acl: &NewDefaultObjectAccessControl,
+    ) -> crate::Result<DefaultObjectAccessControl> {
+        let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, percent_encode(bucket));
+        let result: GoogleResponse<DefaultObjectAccessControl> = self
+            .0
+            .client
+            .post(&url)
+            .headers(self.0.get_headers().await?)
+            .json(new_acl)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(mut s) => {
+                s.bucket = bucket.to_string();
+                Ok(s)
+            }
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Retrieves default object ACL entries on the specified bucket.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::default_object_access_control::DefaultObjectAccessControl;
+    ///
+    /// let client = Client::default();
+    /// let default_acls = client.default_object_access_control().list("mybucket").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self, bucket: &str) -> crate::Result<Vec<DefaultObjectAccessControl>> {
+        let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, percent_encode(bucket));
+        let result: GoogleResponse<ListResponse<DefaultObjectAccessControl>> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s
+                .items
+                .into_iter()
+                .map(|item| DefaultObjectAccessControl {
+                    bucket: bucket.to_string(),
+                    ..item
+                })
+                .collect()),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Read a single `DefaultObjectAccessControl`.
+    /// The `bucket` argument is the name of the bucket whose `DefaultObjectAccessControl` is to be
+    /// read, and the `entity` argument is the entity holding the permission. Options are
+    /// Can be "user-`userId`", "user-`email_address`", "group-`group_id`", "group-`email_address`",
+    /// "allUsers", or "allAuthenticatedUsers".
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let default_acl = client.default_object_access_control().read("mybucket", &Entity::AllUsers).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(
+        &self,
+        bucket: &str,
+        entity: &Entity,
+    ) -> crate::Result<DefaultObjectAccessControl> {
+        let url = format!(
+            "{}/b/{}/defaultObjectAcl/{}",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(&entity.to_string()),
+        );
+        let result: GoogleResponse<DefaultObjectAccessControl> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(mut s) => {
+                s.bucket = bucket.to_string();
+                Ok(s)
+            }
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Update the current `DefaultObjectAccessControl`.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let mut default_acl = client.default_object_access_control().read("my_bucket", &Entity::AllUsers).await?;
+    /// default_acl.entity = Entity::AllAuthenticatedUsers;
+    /// client.default_object_access_control().update(&default_acl).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(
+        &self,
+        default_object_access_control: &DefaultObjectAccessControl,
+    ) -> crate::Result<DefaultObjectAccessControl> {
+        let url = format!(
+            "{}/b/{}/defaultObjectAcl/{}",
+            crate::BASE_URL,
+            percent_encode(&default_object_access_control.bucket),
+            percent_encode(&default_object_access_control.entity.to_string()),
+        );
+        let result: GoogleResponse<DefaultObjectAccessControl> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(default_object_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(mut s) => {
+                s.bucket = default_object_access_control.bucket.to_string();
+                Ok(s)
+            }
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Delete this 'DefaultObjectAccessControl`.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let mut default_acl = client.default_object_access_control().read("my_bucket", &Entity::AllUsers).await?;
+    /// client.default_object_access_control().delete(default_acl).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(
+        &self,
+        default_object_access_control: DefaultObjectAccessControl,
+    ) -> Result<(), crate::Error> {
+        let url = format!(
+            "{}/b/{}/defaultObjectAcl/{}",
+            crate::BASE_URL,
+            percent_encode(&default_object_access_control.bucket),
+            percent_encode(&default_object_access_control.entity.to_string()),
+        );
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/client/hmac_key.rs
+++ b/vendor/cloud-storage-rs/src/client/hmac_key.rs
@@ -1,0 +1,236 @@
+use crate::{
+    error::GoogleResponse,
+    hmac_key::{HmacKey, HmacMeta, HmacState},
+};
+
+/// Operations on [`HmacKey`](HmacKey)s.
+#[derive(Debug)]
+pub struct HmacKeyClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> HmacKeyClient<'a> {
+    /// Creates a new HMAC key for the specified service account.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.create` permission for the project in
+    /// which the key will be created.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::default();
+    /// let hmac_key = client.hmac_key().create().await?;
+    /// # use cloud_storage::hmac_key::HmacState;
+    /// # client.hmac_key().update(&hmac_key.metadata.access_id, HmacState::Inactive).await?;
+    /// # client.hmac_key().delete(&hmac_key.metadata.access_id).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(&self) -> crate::Result<HmacKey> {
+        use reqwest::header::CONTENT_LENGTH;
+
+        let url = format!(
+            "{}/projects/{}/hmacKeys",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id
+        );
+        let query = [("serviceAccountEmail", &crate::SERVICE_ACCOUNT.client_email)];
+        let mut headers = self.0.get_headers().await?;
+        headers.insert(CONTENT_LENGTH, 0.into());
+        let result: GoogleResponse<HmacKey> = self
+            .0
+            .client
+            .post(&url)
+            .headers(headers)
+            .query(&query)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Retrieves a list of HMAC keys matching the criteria. Since the HmacKey is secret, this does
+    /// not return a `HmacKey`, but a `HmacMeta`. This is a redacted version of a `HmacKey`, but
+    /// with the secret data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.list` permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::default();
+    /// let all_hmac_keys = client.hmac_key().list().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self) -> crate::Result<Vec<HmacMeta>> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id
+        );
+        let response = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .text()
+            .await?;
+        let result: Result<GoogleResponse<crate::hmac_key::ListResponse>, _> =
+            serde_json::from_str(&response);
+
+        // This function rquires more complicated error handling because when there is only one
+        // entry, Google will return the response `{ "kind": "storage#hmacKeysMetadata" }` instead
+        // of a list with one element. This breaks the parser.
+        match result {
+            Ok(parsed) => match parsed {
+                GoogleResponse::Success(s) => Ok(s.items),
+                GoogleResponse::Error(e) => Err(e.into()),
+            },
+            Err(_) => Ok(vec![]),
+        }
+    }
+
+    /// Retrieves an HMAC key's metadata. Since the HmacKey is secret, this does not return a
+    /// `HmacKey`, but a `HmacMeta`. This is a redacted version of a `HmacKey`, but with the secret
+    /// data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.get` permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::default();
+    /// let key = client.hmac_key().read("some identifier").await?;
+    /// # Ok(())
+    /// # }
+    pub async fn read(&self, access_id: &str) -> crate::Result<HmacMeta> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys/{}",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id,
+            access_id
+        );
+        let result: GoogleResponse<HmacMeta> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Updates the state of an HMAC key. See the HMAC Key resource descriptor for valid states.
+    /// Since the HmacKey is secret, this does not return a `HmacKey`, but a `HmacMeta`. This is a
+    /// redacted version of a `HmacKey`, but with the secret data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.update` permission for the project in
+    /// which the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::hmac_key::{HmacKey, HmacState};
+    ///
+    /// let client = Client::default();
+    /// let key = client.hmac_key().update("your key", HmacState::Active).await?;
+    /// # Ok(())
+    /// # }
+    pub async fn update(&self, access_id: &str, state: HmacState) -> crate::Result<HmacMeta> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys/{}",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id,
+            access_id
+        );
+        serde_json::to_string(&crate::hmac_key::UpdateMeta { state })?;
+        let result: GoogleResponse<HmacMeta> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(&crate::hmac_key::UpdateMeta { state })
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Deletes an HMAC key. Note that a key must be set to `Inactive` first.
+    ///
+    /// The authenticated user must have storage.hmacKeys.delete permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::hmac_key::{HmacKey, HmacState};
+    ///
+    /// let client = Client::default();
+    /// let key = client.hmac_key().update("your key", HmacState::Inactive).await?; // this is required.
+    /// client.hmac_key().delete(&key.access_id).await?;
+    /// # Ok(())
+    /// # }
+    pub async fn delete(&self, access_id: &str) -> crate::Result<()> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys/{}",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id,
+            access_id
+        );
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/client/object.rs
+++ b/vendor/cloud-storage-rs/src/client/object.rs
@@ -1,0 +1,625 @@
+use futures::{stream, Stream, TryStream};
+use reqwest::StatusCode;
+
+use crate::{
+    error::GoogleResponse,
+    object::{percent_encode, ComposeRequest, ObjectList, RewriteResponse, SizedByteStream},
+    ListRequest, Object,
+};
+
+// Object uploads has its own url for some reason
+const BASE_URL: &str = "https://storage.googleapis.com/upload/storage/v1/b";
+
+/// Operations on [`Object`](Object)s.
+#[derive(Debug)]
+pub struct ObjectClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> ObjectClient<'a> {
+    /// Create a new object with optional headers.
+    ///
+    /// You may wish to use [Preconditions](https://cloud.google.com/storage/docs/generations-preconditions)
+    /// when uploading data. This provides a option for a list of "mix-in" headers to apply
+    /// to create requests.
+    ///
+    /// ## Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn read_cute_cat(_in: &str) -> Vec<u8> { vec![0, 1] }
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let file: Vec<u8> = read_cute_cat("cat.png");
+    /// let client = Client::default();
+    ///
+    /// let headers = reqwest::header::HeaderMap;
+    /// // Do not upload if cat.png is already present.
+    /// headers.append(
+    ///     "if-generation-match",
+    ///      reqwest::header::HeaderValue::from_str("0").unwrap());
+    ///
+    /// client.object().create_with_headers("cat-photos", file, "recently read cat.png", "image/png", Some(headers)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create_with_headers(
+        &self,
+        bucket: &str,
+        file: Vec<u8>,
+        filename: &str,
+        mime_type: &str,
+        addtional_headers: Option<reqwest::header::HeaderMap>,
+    ) -> crate::Result<Object> {
+        use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
+
+        let url = &format!(
+            "{}/{}/o?uploadType=media&name={}",
+            BASE_URL,
+            percent_encode(&bucket),
+            percent_encode(&filename),
+        );
+        let mut headers = self.0.get_headers().await?;
+        if let Some(add_ins) = additional_headers {
+            for key in add_ins.keys() {
+                headers.insert(key, add_ins.get(key).unwrap().clone());
+            }
+        }
+        headers.insert(CONTENT_TYPE, mime_type.parse()?);
+        headers.insert(CONTENT_LENGTH, file.len().to_string().parse()?);
+        let response = self
+            .0
+            .client
+            .post(url)
+            .headers(headers)
+            .body(file)
+            .send()
+            .await?;
+        if response.status() == 200 {
+            Ok(serde_json::from_str(&response.text().await?)?)
+        } else {
+            Err(crate::Error::new(&response.text().await?))
+        }
+    }
+
+    /// Create a new object.
+    /// Upload a file as that is loaded in memory to google cloud storage, where it will be
+    /// interpreted according to the mime type you specified.
+    /// ## Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn read_cute_cat(_in: &str) -> Vec<u8> { vec![0, 1] }
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let file: Vec<u8> = read_cute_cat("cat.png");
+    /// let client = Client::default();
+    /// client.object().create("cat-photos", file, "recently read cat.png", "image/png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(
+        &self,
+        bucket: &str,
+        file: Vec<u8>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Object> {
+        self.create_with_headers(bucket, file, filename, mime_type, None).await
+    }
+
+    /// Create a new object. This works in the same way as `ObjectClient::create`, except it does not need
+    /// to load the entire file in ram.
+    /// ## Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::default();
+    /// let file = reqwest::Client::new()
+    ///     .get("https://my_domain.rs/nice_cat_photo.png")
+    ///     .send()
+    ///     .await?
+    ///     .bytes_stream();
+    /// client.object().create_streamed("cat-photos", file, 10, "recently read cat.png", "image/png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create_streamed<S>(
+        &self,
+        bucket: &str,
+        stream: S,
+        length: impl Into<Option<u64>>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Object>
+    where
+        S: TryStream + Send + Sync + 'static,
+        S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        bytes::Bytes: From<S::Ok>,
+    {
+        use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
+
+        let url = &format!(
+            "{}/{}/o?uploadType=media&name={}",
+            BASE_URL,
+            percent_encode(&bucket),
+            percent_encode(&filename),
+        );
+        let mut headers = self.0.get_headers().await?;
+        headers.insert(CONTENT_TYPE, mime_type.parse()?);
+        if let Some(length) = length.into() {
+            headers.insert(CONTENT_LENGTH, length.into());
+        }
+
+        let body = reqwest::Body::wrap_stream(stream);
+        let response = self
+            .0
+            .client
+            .post(url)
+            .headers(headers)
+            .body(body)
+            .send()
+            .await?;
+        if response.status() == 200 {
+            Ok(serde_json::from_str(&response.text().await?)?)
+        } else {
+            Err(crate::Error::new(&response.text().await?))
+        }
+    }
+
+    /// Obtain a list of objects within this Bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::{Object, ListRequest};
+    ///
+    /// let client = Client::default();
+    /// let all_objects = client.object().list("my_bucket", ListRequest::default()).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(
+        &self,
+        bucket: &'a str,
+        list_request: ListRequest,
+    ) -> crate::Result<impl Stream<Item = crate::Result<ObjectList>> + 'a> {
+        enum ListState {
+            Start(ListRequest),
+            HasMore(ListRequest),
+            Done,
+        }
+        use ListState::*;
+        impl ListState {
+            fn into_has_more(self) -> Option<ListState> {
+                match self {
+                    Start(req) | HasMore(req) => Some(HasMore(req)),
+                    Done => None,
+                }
+            }
+
+            fn req_mut(&mut self) -> Option<&mut ListRequest> {
+                match self {
+                    Start(ref mut req) | HasMore(ref mut req) => Some(req),
+                    Done => None,
+                }
+            }
+        }
+
+        let client = self.0;
+
+        Ok(stream::unfold(
+            ListState::Start(list_request),
+            move |mut state| async move {
+                let url = format!("{}/b/{}/o", crate::BASE_URL, percent_encode(bucket));
+                let headers = match client.get_headers().await {
+                    Ok(h) => h,
+                    Err(e) => return Some((Err(e), state)),
+                };
+                let req = state.req_mut()?;
+                if req.max_results == Some(0) {
+                    return None;
+                }
+
+                let response = client
+                    .client
+                    .get(&url)
+                    .query(req)
+                    .headers(headers)
+                    .send()
+                    .await;
+
+                let response = match response {
+                    Ok(r) if r.status() == 200 => r,
+                    Ok(r) => {
+                        let e = match r.json::<crate::error::GoogleErrorResponse>().await {
+                            Ok(err_res) => err_res.into(),
+                            Err(serde_err) => serde_err.into(),
+                        };
+                        return Some((Err(e), state));
+                    }
+                    Err(e) => return Some((Err(e.into()), state)),
+                };
+
+                let result: GoogleResponse<ObjectList> = match response.json().await {
+                    Ok(json) => json,
+                    Err(e) => return Some((Err(e.into()), state)),
+                };
+
+                let response_body = match result {
+                    GoogleResponse::Success(success) => success,
+                    GoogleResponse::Error(e) => return Some((Err(e.into()), state)),
+                };
+
+                let next_state = if let Some(ref page_token) = response_body.next_page_token {
+                    req.page_token = Some(page_token.clone());
+                    req.max_results = req
+                        .max_results
+                        .map(|rem| rem.saturating_sub(response_body.items.len()));
+                    state.into_has_more()?
+                } else {
+                    Done
+                };
+
+                Some((Ok(response_body), next_state))
+            },
+        ))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::default();
+    /// let object = client.object().read("my_bucket", "path/to/my/file.png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(&self, bucket: &str, file_name: &str) -> crate::Result<Object> {
+        let url = format!(
+            "{}/b/{}/o/{}",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        let result: GoogleResponse<Object> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Download the content of the object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::default();
+    /// let bytes = client.object().download("my_bucket", "path/to/my/file.png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn download(&self, bucket: &str, file_name: &str) -> crate::Result<Vec<u8>> {
+        let url = format!(
+            "{}/b/{}/o/{}?alt=media",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        let resp = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if resp.status() == StatusCode::NOT_FOUND {
+            Err(crate::Error::Other(resp.text().await?))
+        } else {
+            Ok(resp.error_for_status()?.bytes().await?.to_vec())
+        }
+    }
+
+    /// Download the content of the object with the specified name in the specified bucket, without
+    /// allocating the whole file into a vector.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    /// use futures::StreamExt;
+    /// use std::fs::File;
+    /// use std::io::{BufWriter, Write};
+    ///
+    /// let client = Client::default();
+    /// let mut stream = client.object().download_streamed("my_bucket", "path/to/my/file.png").await?;
+    /// let mut file = BufWriter::new(File::create("file.png").unwrap());
+    /// while let Some(byte) = stream.next().await {
+    ///     file.write_all(&[byte.unwrap()]).unwrap();
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn download_streamed(
+        &self,
+        bucket: &str,
+        file_name: &str,
+    ) -> crate::Result<impl Stream<Item = crate::Result<u8>> + Unpin> {
+        use futures::{StreamExt, TryStreamExt};
+        let url = format!(
+            "{}/b/{}/o/{}?alt=media",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        let response = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .error_for_status()?;
+        let size = response.content_length();
+        let bytes = response
+            .bytes_stream()
+            .map(|chunk| chunk.map(|c| futures::stream::iter(c.into_iter().map(Ok))))
+            .try_flatten();
+        Ok(SizedByteStream::new(bytes, size))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::default();
+    /// let mut object = client.object().read("my_bucket", "path/to/my/file.png").await?;
+    /// object.content_type = Some("application/xml".to_string());
+    /// client.object().update(&object).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(&self, object: &Object) -> crate::Result<Object> {
+        let url = format!(
+            "{}/b/{}/o/{}",
+            crate::BASE_URL,
+            percent_encode(&object.bucket),
+            percent_encode(&object.name),
+        );
+        let result: GoogleResponse<Object> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(&object)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Deletes a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::default();
+    /// client.object().delete("my_bucket", "path/to/my/file.png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(&self, bucket: &str, file_name: &str) -> crate::Result<()> {
+        let url = format!(
+            "{}/b/{}/o/{}",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::object::{Object, ComposeRequest, SourceObject};
+    ///
+    /// let client = Client::default();
+    /// let obj1 = client.object().read("my_bucket", "file1").await?;
+    /// let obj2 = client.object().read("my_bucket", "file2").await?;
+    /// let compose_request = ComposeRequest {
+    ///     kind: "storage#composeRequest".to_string(),
+    ///     source_objects: vec![
+    ///         SourceObject {
+    ///             name: obj1.name.clone(),
+    ///             generation: None,
+    ///             object_preconditions: None,
+    ///         },
+    ///         SourceObject {
+    ///             name: obj2.name.clone(),
+    ///             generation: None,
+    ///             object_preconditions: None,
+    ///         },
+    ///     ],
+    ///     destination: None,
+    /// };
+    /// let obj3 = client.object().compose("my_bucket", &compose_request, "test-concatted-file").await?;
+    /// // obj3 is now a file with the content of obj1 and obj2 concatted together.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn compose(
+        &self,
+        bucket: &str,
+        req: &ComposeRequest,
+        destination_object: &str,
+    ) -> crate::Result<Object> {
+        let url = format!(
+            "{}/b/{}/o/{}/compose",
+            crate::BASE_URL,
+            percent_encode(&bucket),
+            percent_encode(&destination_object)
+        );
+        let result: GoogleResponse<Object> = self
+            .0
+            .client
+            .post(&url)
+            .headers(self.0.get_headers().await?)
+            .json(req)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Copy this object to the target bucket and path
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::object::{Object, ComposeRequest};
+    ///
+    /// let client = Client::default();
+    /// let obj1 = client.object().read("my_bucket", "file1").await?;
+    /// let obj2 = client.object().copy(&obj1, "my_other_bucket", "file2").await?;
+    /// // obj2 is now a copy of obj1.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn copy(
+        &self,
+        object: &Object,
+        destination_bucket: &str,
+        path: &str,
+    ) -> crate::Result<Object> {
+        use reqwest::header::CONTENT_LENGTH;
+
+        let url = format!(
+            "{base}/b/{sBucket}/o/{sObject}/copyTo/b/{dBucket}/o/{dObject}",
+            base = crate::BASE_URL,
+            sBucket = percent_encode(&object.bucket),
+            sObject = percent_encode(&object.name),
+            dBucket = percent_encode(&destination_bucket),
+            dObject = percent_encode(&path),
+        );
+        let mut headers = self.0.get_headers().await?;
+        headers.insert(CONTENT_LENGTH, "0".parse()?);
+        let result: GoogleResponse<Object> = self
+            .0
+            .client
+            .post(&url)
+            .headers(headers)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Moves a file from the current location to the target bucket and path.
+    ///
+    /// ## Limitations
+    /// This function does not yet support rewriting objects to another
+    /// * Geographical Location,
+    /// * Encryption,
+    /// * Storage class.
+    /// These limitations mean that for now, the rewrite and the copy methods do the same thing.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::object::Object;
+    ///
+    /// let client = Client::default();
+    /// let obj1 = client.object().read("my_bucket", "file1").await?;
+    /// let obj2 = client.object().rewrite(&obj1, "my_other_bucket", "file2").await?;
+    /// // obj2 is now a copy of obj1.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn rewrite(
+        &self,
+        object: &Object,
+        destination_bucket: &str,
+        path: &str,
+    ) -> crate::Result<Object> {
+        use reqwest::header::CONTENT_LENGTH;
+
+        let url = format!(
+            "{base}/b/{sBucket}/o/{sObject}/rewriteTo/b/{dBucket}/o/{dObject}",
+            base = crate::BASE_URL,
+            sBucket = percent_encode(&object.bucket),
+            sObject = percent_encode(&object.name),
+            dBucket = percent_encode(destination_bucket),
+            dObject = percent_encode(path),
+        );
+        let mut headers = self.0.get_headers().await?;
+        headers.insert(CONTENT_LENGTH, "0".parse()?);
+        let result: GoogleResponse<RewriteResponse> = self
+            .0
+            .client
+            .post(&url)
+            .headers(headers)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.resource),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/client/object_access_control.rs
+++ b/vendor/cloud-storage-rs/src/client/object_access_control.rs
@@ -1,0 +1,174 @@
+use crate::{
+    bucket_access_control::Entity,
+    object::percent_encode,
+    error::GoogleResponse,
+    object_access_control::{NewObjectAccessControl, ObjectAccessControl},
+    resources::common::ListResponse,
+};
+
+/// Operations on [`ObjectAccessControl`](ObjectAccessControl)s.
+#[derive(Debug)]
+pub struct ObjectAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> ObjectAccessControlClient<'a> {
+    /// Creates a new ACL entry on the specified `object`.
+    ///
+    /// ### Important
+    /// This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn create(
+        &self,
+        bucket: &str,
+        object: &str,
+        new_object_access_control: &NewObjectAccessControl,
+    ) -> crate::Result<ObjectAccessControl> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(object),
+        );
+        let result: GoogleResponse<ObjectAccessControl> = self
+            .0
+            .client
+            .post(&url)
+            .headers(self.0.get_headers().await?)
+            .json(new_object_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Retrieves `ACL` entries on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn list(
+        &self,
+        bucket: &str,
+        object: &str,
+    ) -> crate::Result<Vec<ObjectAccessControl>> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(object),
+        );
+        let result: GoogleResponse<ListResponse<ObjectAccessControl>> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.items),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Returns the `ACL` entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn read(
+        &self,
+        bucket: &str,
+        object: &str,
+        entity: &Entity,
+    ) -> crate::Result<ObjectAccessControl> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl/{}",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(object),
+            percent_encode(&entity.to_string())
+        );
+        let result: GoogleResponse<ObjectAccessControl> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Updates an ACL entry on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn update(
+        &self,
+        object_access_control: &ObjectAccessControl,
+    ) -> crate::Result<ObjectAccessControl> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl/{}",
+            crate::BASE_URL,
+            percent_encode(&object_access_control.bucket),
+            percent_encode(&object_access_control.object),
+            percent_encode(&object_access_control.entity.to_string()),
+        );
+        let result: GoogleResponse<ObjectAccessControl> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(object_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Permanently deletes the ACL entry for the specified entity on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn delete(&self, object_access_control: ObjectAccessControl) -> crate::Result<()> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl/{}",
+            crate::BASE_URL,
+            percent_encode(&object_access_control.bucket),
+            percent_encode(&object_access_control.object),
+            percent_encode(&object_access_control.entity.to_string()),
+        );
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/download_options.rs
+++ b/vendor/cloud-storage-rs/src/download_options.rs
@@ -1,0 +1,33 @@
+/// A set of parameters that can be used to customise signed urls.
+#[derive(Default)]
+pub struct DownloadOptions {
+    pub(crate) content_disposition: Option<String>,
+}
+
+impl DownloadOptions {
+    /// Create a new instance of `DownloadOptions`. Equivalent to `DownloadOptions::default()`.
+    ///
+    /// ### Example
+    /// ```rust
+    /// use cloud_storage::DownloadOptions;
+    ///
+    /// let opts = DownloadOptions::new();
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a new instance of `DownloadOptions`. Equivalent to `DownloadOptions::default()`.
+    ///
+    /// ### Example
+    /// ```rust
+    /// use cloud_storage::DownloadOptions;
+    ///
+    /// let opts = DownloadOptions::new()
+    ///     .content_disposition("attachment");
+    /// ```
+    pub fn content_disposition(mut self, content_disposition: &str) -> Self {
+        self.content_disposition = Some(content_disposition.to_string());
+        self
+    }
+}

--- a/vendor/cloud-storage-rs/src/error.rs
+++ b/vendor/cloud-storage-rs/src/error.rs
@@ -1,0 +1,409 @@
+/// Represents any of the ways storing something in Google Cloud Storage can fail.
+#[derive(Debug)]
+pub enum Error {
+    /// If the error is caused by a non 2xx response by Google, this variant is returned.
+    Google(GoogleErrorResponse),
+    /// If another network error causes something to fail, this variant is used.
+    Reqwest(reqwest::Error),
+    /// If we encouter a SSL error, for example an invalid certificate, this variant is used.
+    Ssl(openssl::error::ErrorStack),
+    /// If we have problems creating or parsing a json web token, this variant is used.
+    Jwt(jsonwebtoken::errors::Error),
+    /// If we cannot deserialize one of the repsonses sent by Google, this variant is used.
+    Serialization(serde_json::error::Error),
+    /// If another failure causes the error, this variant is populated.
+    Other(String),
+}
+
+impl Error {
+    pub(crate) fn new(msg: &str) -> Error {
+        Error::Other(msg.to_string())
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        writeln!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Google(e) => Some(e),
+            Self::Reqwest(e) => Some(e),
+            Self::Ssl(e) => Some(e),
+            Self::Jwt(e) => Some(e),
+            Self::Serialization(e) => Some(e),
+            Self::Other(_) => None,
+        }
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Reqwest(err)
+    }
+}
+
+impl From<openssl::error::ErrorStack> for Error {
+    fn from(err: openssl::error::ErrorStack) -> Self {
+        Self::Ssl(err)
+    }
+}
+
+impl From<jsonwebtoken::errors::Error> for Error {
+    fn from(err: jsonwebtoken::errors::Error) -> Self {
+        Self::Jwt(err)
+    }
+}
+
+impl From<serde_json::error::Error> for Error {
+    fn from(err: serde_json::error::Error) -> Self {
+        Self::Serialization(err)
+    }
+}
+
+impl From<reqwest::header::InvalidHeaderValue> for Error {
+    fn from(err: reqwest::header::InvalidHeaderValue) -> Self {
+        Self::Other(err.to_string())
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename = "camelCase")]
+#[serde(untagged)]
+pub(crate) enum GoogleResponse<T> {
+    Success(T),
+    Error(GoogleErrorResponse),
+}
+
+// TODO comment this in when try_trait (#42327) get stabilized and enjoy the nicer handling of
+// errors
+//
+// impl<T> std::ops::Try for GoogleResponse<T> {
+//     type Ok = T;
+//     type Error = Error;
+//
+//     fn into_result(self) -> Result<Self::Ok, Error> {
+//         match self {
+//             GoogleResponse::Success(t) => Ok(t),
+//             GoogleResponse::Error(error) => Err(Error::Google(error)),
+//         }
+//     }
+//
+//     fn from_error(_a: Error) -> Self {
+//         unimplemented!()
+//     }
+//
+//     fn from_ok(t: T) -> Self {
+//         GoogleResponse::Success(t)
+//     }
+// }
+
+/// The structure of a error response returned by Google.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename = "camelCase")]
+pub struct GoogleErrorResponse {
+    error: ErrorList,
+}
+
+impl GoogleErrorResponse {
+    /// Return list of errors returned by Google
+    pub fn errors(&self) -> &[GoogleError] {
+        &self.error.errors
+    }
+
+    /// Check whether errors contain given reason
+    pub fn errors_has_reason(&self, reason: &Reason) -> bool {
+        self.errors()
+            .iter()
+            .any(|google_error| google_error.is_reason(reason))
+    }
+}
+
+impl std::fmt::Display for GoogleErrorResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        writeln!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for GoogleErrorResponse {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename = "camelCase")]
+struct ErrorList {
+    errors: Vec<GoogleError>,
+    code: u16,
+    message: String,
+}
+
+/// Google Error structure
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename = "camelCase")]
+pub struct GoogleError {
+    domain: String,
+    reason: Reason,
+    message: String,
+    location_type: Option<String>,
+    location: Option<String>,
+}
+
+impl GoogleError {
+    /// Check what was the reasons of error
+    pub fn is_reason(&self, reason: &Reason) -> bool {
+        &self.reason == reason
+    }
+}
+
+impl From<GoogleErrorResponse> for Error {
+    fn from(err: GoogleErrorResponse) -> Self {
+        Self::Google(err)
+    }
+}
+
+/// Google provides a list of codes, but testing indicates that this list is not exhaustive.
+#[derive(Debug, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Reason {
+    /// When requesting a download using alt=media URL parameter, the direct URL path to use is
+    /// prefixed by /download. If this is omitted, the service will issue this redirect with the
+    /// appropriate media download path in the Location header.
+    MediaDownloadRedirect,
+    /// The conditional request would have been successful, but the condition was false, so no body
+    /// was sent.
+    NotModified,
+    /// Resource temporarily located elsewhere according to the Location header. Among other
+    /// reasons, this can occur when cookie-based authentication is being used, e.g., when using the
+    /// Storage Browser, and it receives a request to download content.
+    TemporaryRedirect,
+    // /// Indicates an incomplete resumable upload and provides the range of bytes already received by
+    // /// Cloud Storage. Responses with this status do not contain a body.
+    // ResumeIncomplete,
+
+    // <bad requests>
+    /// Undocumeten variant that is sometimes returned by Google.
+    Invalid,
+    /// The request cannot be completed based on your current Cloud Storage settings. For example,
+    /// you cannot lock a retention policy if the requested bucket doesn't have a retention policy,
+    /// and you cannot set ACLs if the requested bucket has Bucket Policy Only enabled.
+    BadRequest,
+    /// The retention period on a locked bucket cannot be reduced.
+    BadRequestException,
+    /// Bad Cloud KMS key.
+    CloudKmsBadKey,
+    /// Cloud KMS key name cannot be changed.
+    CloudKmsCannotChangeKeyName,
+    /// Resource's Cloud KMS decryption key not found.
+    CloudKmsDecryptionKeyNotFound,
+    /// Cloud KMS key is disabled, destroyed, or scheduled to be destroyed.
+    CloudKmsDisabledKey,
+    /// Cloud KMS encryption key not found.
+    CloudKmsEncryptionKeyNotFound,
+    /// Cloud KMS key location not allowed.
+    CloudKmsKeyLocationNotAllowed,
+    /// Missing an encryption algorithm, or the provided algorithm is not "AE256."
+    CustomerEncryptionAlgorithmIsInvalid,
+    /// Missing an encryption key, or it is not Base64 encoded, or it does not meet the required
+    /// length of the encryption algorithm.
+    CustomerEncryptionKeyFormatIsInvalid,
+    /// The provided encryption key is incorrect.
+    CustomerEncryptionKeyIsIncorrect,
+    /// Missing a SHA256 hash of the encryption key, or it is not Base64 encoded, or it does not
+    /// match the encryption key.
+    CustomerEncryptionKeySha256IsInvalid,
+    /// The value for the alt URL parameter was not recognized.
+    InvalidAltValue,
+    /// The value for one of fields in the request body was invalid.
+    InvalidArgument,
+    /// The value for one of the URL parameters was invalid. In addition to normal URL parameter
+    /// validation, any URL parameters that have a corresponding value in provided JSON request
+    /// bodies must match if they are both specified. If using JSONP, you will get this error if you
+    /// provide an alt parameter that is not json.
+    InvalidParameter,
+    /// Uploads or normal API request was sent to a `/download/*` path. Use the same path, but
+    /// without the /download prefix.
+    NotDownload,
+    /// Downloads or normal API request was sent to an `/upload/*` path. Use the same path, but
+    /// without the `/upload` prefix.
+    NotUpload,
+    /// Could not parse the body of the request according to the provided Content-Type.
+    ParseError,
+    /// Channel id must match the following regular expression: `[A-Za-z0-9\\-_\\+/=]+`.
+    #[serde(rename = "push.channelIdInvalid")]
+    PushChannelIdInvalid,
+    /// `storage.objects.watchAll`'s id property must be unique across channels.
+    #[serde(rename = "push.channelIdNotUnique")]
+    PushChannelIdNotUnique,
+    /// `storage.objects.watchAll`'s address property must contain a valid URL.
+    #[serde(rename = "push.webhookUrlNoHostOrAddress")]
+    PushWebhookUrlNoHostOrAddress,
+    /// `storage.objects.watchAll`'s address property must be an HTTPS URL.
+    #[serde(rename = "push.webhookUrlNotHttps")]
+    PushWebhookUrlNotHttps,
+    /// A required URL parameter or required request body JSON property is missing.
+    Required,
+    /// The resource is encrypted with a customer-supplied encryption key, but the request did not
+    /// provide one.
+    ResourceIsEncryptedWithCustomerEncryptionKey,
+    /// The resource is not encrypted with a customer-supplied encryption key, but the request
+    /// provided one.
+    ResourceNotEncryptedWithCustomerEncryptionKey,
+    /// A request was made to an API version that has been turned down. Clients will need to update
+    /// to a supported version.
+    TurnedDown,
+    /// The user project specified in the request does not match the user project specifed in an
+    /// earlier, related request.
+    UserProjectInconsistent,
+    /// The user project specified in the request is invalid, either because it is a malformed
+    /// project id or because it refers to a non-existent project.
+    UserProjectInvalid,
+    /// The requested bucket has Requester Pays enabled, the requester is not an owner of the
+    /// bucket, and no user project was present in the request.
+    UserProjectMissing,
+    /// storage.objects.insert must be invoked as an upload rather than a metadata.
+    WrongUrlForUpload,
+    // </bad requests>
+
+    // <unauthorized>
+    /// Access to a Requester Pays bucket requires authentication.
+    #[serde(rename = "AuthenticationRequiredRequesterPays")]
+    AuthenticationRequiredRequesterPays,
+    /// This error indicates a problem with the authorization provided in the request to Cloud
+    /// Storage. The following are some situations where that will occur:
+    ///
+    /// * The OAuth access token has expired and needs to be refreshed. This can be avoided by
+    ///   refreshing the access token early, but code can also catch this error, refresh the token
+    ///   and retry automatically.
+    /// * Multiple non-matching authorizations were provided; choose one mode only.
+    /// * The OAuth access token's bound project does not match the project associated with the
+    ///   provided developer key.
+    /// * The Authorization header was of an unrecognized format or uses an unsupported credential
+    ///   type.
+    AuthError,
+    /// When downloading content from a cookie-authenticated site, e.g., using the Storage Browser,
+    /// the response will redirect to a temporary domain. This error will occur if access to said
+    /// domain occurs after the domain expires. Issue the original request again, and receive a new
+    /// redirect.
+    LockedDomainExpired,
+    /// Requests to storage.objects.watchAll will fail unless you verify you own the domain.
+    #[serde(rename = "push.webhookUrlUnauthorized")]
+    PushWebhookUrlUnauthorized,
+    // /// Access to a non-public method that requires authorization was made, but none was provided in
+    // /// the Authorization header or through other means.
+    // Required,
+    // </unauthorized>
+
+    // <forbidden>
+    ///  The account associated with the project that owns the bucket or object has been disabled. Check the Google Cloud Console to see if there is a problem with billing, and if not, contact account support.
+    AccountDisabled,
+    /// The Cloud Storage JSON API is restricted by law from operating with certain countries.
+    CountryBlocked,
+    ///  According to access control policy, the current user does not have access to perform the requested action. This code applies even if the resource being acted on doesn't exist.
+    Forbidden,
+    ///  According to access control policy, the current user does not have access to perform the requested action. This code applies even if the resource being acted on doesn't exist.
+    InsufficientPermissions,
+    ///  Object overwrite or deletion is not allowed due to an active hold on the object.
+    ObjectUnderActiveHold,
+    ///  The Cloud Storage rate limit was exceeded. Retry using exponential backoff.
+    RateLimitExceeded,
+    ///  Object overwrite or deletion is not allowed until the object meets the retention period set by the retention policy on the bucket.
+    RetentionPolicyNotMet,
+    ///  Requests to this API require SSL.
+    SslRequired,
+    ///  Calls to storage.channels.stop require that the caller own the channel.
+    StopChannelCallerNotOwner,
+    ///  This error implies that for the project associated with the OAuth token or the developer key provided, access to Cloud Storage JSON API is not enabled. This is most commonly because Cloud Storage JSON API is not enabled in the Google Cloud Console, though there are other cases where the project is blocked or has been deleted when this can occur.
+    #[serde(rename = "UsageLimits.accessNotConfigured")]
+    UsageLimitsAccessNotConfigured,
+    /// The requester is not authorized to use the project specified in their request. The
+    /// requester must have either the serviceusage.services.use permission or the Editor role for
+    /// the specified project.
+    #[serde(rename = "UserProjectAccessDenied")]
+    UserProjectAccessDenied,
+    /// There is a problem with the project used in the request that prevents the operation from
+    /// completing successfully. One issue could be billing. Check the billing page to see if you
+    /// have a past due balance or if the credit card (or other payment mechanism) on your account is expired. For project creation, see the Projects page in the Google Cloud Console. For other problems, see the Resources and Support page.
+    #[serde(rename = "UserProjectAccountProblem")]
+    UserProjectAccountProblem,
+    /// The developer-specified per-user rate quota was exceeded. If you are the developer, then
+    /// you can view these quotas at Quotas pane in the Google Cloud Console.
+    UserRateLimitExceeded,
+    /// Seems to indicate the same thing
+    // NONEXHAUST
+    QuotaExceeded,
+    // </forbidden>
+    /// Either there is no API method associated with the URL path of the request, or the request
+    /// refers to one or more resources that were not found.
+    NotFound,
+    /// Either there is no API method associated with the URL path of the request, or the request
+    /// refers to one or more resources that were not found.
+    MethodNotAllowed,
+    /// The request timed out. Please try again using truncated exponential backoff.
+    UploadBrokenConnection,
+    /// A request to change a resource, usually a storage.*.update or storage.*.patch method, failed
+    /// to commit the change due to a conflicting concurrent change to the same resource. The
+    /// request can be retried, though care should be taken to consider the new state of the
+    /// resource to avoid blind overwriting of other agent's changes.
+    Conflict,
+    /// You have attempted to use a resumable upload session that is no longer available. If the
+    /// reported status code was not successful and you still wish to upload the file, you must
+    /// start a new session.
+    Gone,
+    // /// You must provide the Content-Length HTTP header. This error has no response body.
+    // LengthRequired,
+
+    // <precondition failed>
+    /// At least one of the pre-conditions you specified did not hold.
+    ConditionNotMet,
+    /// Request violates an OrgPolicy constraint.
+    OrgPolicyConstraintFailed,
+    // </precondition failed>
+    /// The Cloud Storage JSON API supports up to 5 TB objects.
+    ///
+    /// This error may, alternatively, arise if copying objects between locations and/or storage
+    /// classes can not complete within 30 seconds. In this case, use the `Object::rewrite` method
+    /// instead.
+    UploadTooLarge,
+    /// The requested Range cannot be satisfied.
+    RequestedRangeNotSatisfiable,
+    /// A [Cloud Storage JSON API usage limit](https://cloud.google.com/storage/quotas) was
+    /// exceeded. If your application tries to use more than its limit, additional requests will
+    /// fail. Throttle your client's requests, and/or use truncated exponential backoff.
+    #[serde(rename = "usageLimits.rateLimitExceeded")]
+    UsageLimitsRateLimitExceeded,
+
+    // <internal server error>
+    /// We encountered an internal error. Please try again using truncated exponential backoff.
+    BackendError,
+    /// We encountered an internal error. Please try again using truncated exponential backoff.
+    InternalError,
+    // </internal server error>
+    /// May be returned by Google, meaning undocumented.
+    // NONEXHAUST
+    GatewayTimeout,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename = "camelCase")]
+enum BadRequest {}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename = "camelCase")]
+enum Unauthorized {}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename = "camelCase")]
+enum Forbidden {}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename = "camelCase")]
+enum PreconditionFailed {}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename = "camelCase")]
+enum InternalServerError {}

--- a/vendor/cloud-storage-rs/src/lib.rs
+++ b/vendor/cloud-storage-rs/src/lib.rs
@@ -89,7 +89,6 @@ mod error;
 mod resources;
 mod token;
 
-pub use download_options::DownloadOptions;
 pub use crate::error::*;
 use crate::resources::service_account::ServiceAccount;
 pub use crate::resources::{
@@ -98,6 +97,7 @@ pub use crate::resources::{
     *,
 };
 use crate::token::Token;
+pub use download_options::DownloadOptions;
 use tokio::sync::Mutex;
 
 lazy_static::lazy_static! {

--- a/vendor/cloud-storage-rs/src/lib.rs
+++ b/vendor/cloud-storage-rs/src/lib.rs
@@ -1,0 +1,214 @@
+//! This crate aims to simplify interacting with the Google Cloud Storage JSON API. Use it until
+//! Google releases a Cloud Storage Client Library for Rust. Shoutout to
+//! [MyEmma](https://myemma.io/) for funding this free and open source project.
+//!
+//! Google Cloud Storage is a product by Google that allows for cheap file storage, with a
+//! relatively sophisticated API. The idea is that storage happens in `Bucket`s, which are
+//! filesystems with a globally unique name. You can make as many of these `Bucket`s as you like!
+//!
+//! This project talks to Google using a `Service Account`. A service account is an account that you
+//! must create in the [cloud storage console](https://console.cloud.google.com/). When the account
+//! is created, you can download the file `service-account-********.json`. Store this file somewhere
+//! on your machine, and place the path to this file in the environment parameter `SERVICE_ACCOUNT`.
+//! Environment parameters declared in the `.env` file are also registered. The service account can
+//! then be granted `Roles` in the cloud storage console. The roles required for this project to
+//! function are `Service Account Token Creator` and `Storage Object Admin`.
+//!
+//! # Quickstart
+//! Add the following line to your `Cargo.toml`
+//! ```toml
+//! [dependencies]
+//! cloud-storage = "0.6"
+//! ```
+//! The two most important concepts are [Buckets](bucket/struct.Bucket.html), which represent
+//! file systems, and [Objects](object/struct.Object.html), which represent files.
+//!
+//! ## Examples:
+//! Creating a new Bucket in Google Cloud Storage:
+//! ```rust
+//! # use cloud_storage::{Bucket, NewBucket};
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let bucket = Bucket::create(&NewBucket {
+//!     name: "doctest-bucket".to_string(),
+//!     ..Default::default()
+//! }).await?;
+//! # bucket.delete().await?;
+//! # Ok(())
+//! # }
+//! ```
+//! Connecting to an existing Bucket in Google Cloud Storage:
+//! ```no_run
+//! # use cloud_storage::Bucket;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let bucket = Bucket::read("mybucket").await?;
+//! # Ok(())
+//! # }
+//! ```
+//! Read a file from disk and store it on googles server:
+//! ```rust,no_run
+//! # use cloud_storage::Object;
+//! # use std::fs::File;
+//! # use std::io::Read;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut bytes: Vec<u8> = Vec::new();
+//! for byte in File::open("myfile.txt")?.bytes() {
+//!     bytes.push(byte?)
+//! }
+//! Object::create("mybucket", bytes, "myfile.txt", "text/plain").await?;
+//! # Ok(())
+//! # }
+//! ```
+//! Renaming/moving a file
+//! ```rust,no_run
+//! # use cloud_storage::Object;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut object = Object::read("mybucket", "myfile").await?;
+//! object.name = "mybetterfile".to_string();
+//! object.update().await?;
+//! # Ok(())
+//! # }
+//! ```
+//! Removing a file
+//! ```rust,no_run
+//! # use cloud_storage::Object;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! Object::delete("mybucket", "myfile").await?;
+//! # Ok(())
+//! # }
+//! ```
+#![forbid(unsafe_code, missing_docs)]
+
+mod download_options;
+/// Contains objects as represented by Google, to be used for serialization and deserialization.
+mod error;
+mod resources;
+mod token;
+
+pub use download_options::DownloadOptions;
+pub use crate::error::*;
+use crate::resources::service_account::ServiceAccount;
+pub use crate::resources::{
+    bucket::{Bucket, NewBucket},
+    object::Object,
+    *,
+};
+use crate::token::Token;
+use tokio::sync::Mutex;
+
+lazy_static::lazy_static! {
+    /// Static `Token` struct that caches
+    static ref TOKEN_CACHE: Mutex<Token> = Mutex::new(Token::new(
+        "https://www.googleapis.com/auth/devstorage.full_control",
+    ));
+
+    static ref IAM_TOKEN_CACHE: Mutex<Token> = Mutex::new(Token::new(
+        "https://www.googleapis.com/auth/iam"
+    ));
+
+    /// The struct is the parsed service account json file. It is publicly exported to enable easier
+    /// debugging of which service account is currently used. It is of the type
+    /// [ServiceAccount](service_account/struct.ServiceAccount.html).
+    pub static ref SERVICE_ACCOUNT: ServiceAccount = ServiceAccount::get();
+}
+
+/// A type alias where the error is set to be `cloud_storage::Error`.
+pub type Result<T> = std::result::Result<T, crate::Error>;
+
+const BASE_URL: &str = "https://www.googleapis.com/storage/v1";
+
+async fn get_headers() -> Result<reqwest::header::HeaderMap> {
+    let mut result = reqwest::header::HeaderMap::new();
+    let mut guard = TOKEN_CACHE.lock().await;
+    let token = guard.get().await?;
+    result.insert(
+        reqwest::header::AUTHORIZATION,
+        format!("Bearer {}", token).parse().unwrap(),
+    );
+    Ok(result)
+}
+
+fn from_str<'de, T, D>(deserializer: D) -> std::result::Result<T, D::Error>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Deserialize;
+    let s = String::deserialize(deserializer)?;
+    T::from_str(&s).map_err(serde::de::Error::custom)
+}
+
+fn from_str_opt<'de, T, D>(deserializer: D) -> std::result::Result<Option<T>, D::Error>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+    D: serde::Deserializer<'de>,
+{
+    let s: std::result::Result<serde_json::Value, _> =
+        serde::Deserialize::deserialize(deserializer);
+    match s {
+        Ok(serde_json::Value::String(s)) => T::from_str(&s)
+            .map_err(serde::de::Error::custom)
+            .map(Option::from),
+        Ok(serde_json::Value::Number(num)) => T::from_str(&num.to_string())
+            .map_err(serde::de::Error::custom)
+            .map(Option::from),
+        Ok(_value) => Err(serde::de::Error::custom("Incorrect type")),
+        Err(_) => Ok(None),
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "sync")]
+#[tokio::main]
+async fn read_test_bucket_sync() -> Bucket {
+    read_test_bucket().await
+}
+
+#[cfg(test)]
+async fn read_test_bucket() -> Bucket {
+    dotenv::dotenv().ok();
+    let name = std::env::var("TEST_BUCKET").unwrap();
+    match Bucket::read(&name).await {
+        Ok(bucket) => bucket,
+        Err(_not_found) => Bucket::create(&NewBucket {
+            name,
+            ..NewBucket::default()
+        })
+        .await
+        .unwrap(),
+    }
+}
+
+// since all tests run in parallel, we need to make sure we do not create multiple buckets with
+// the same name in each test.
+#[cfg(test)]
+#[cfg(feature = "sync")]
+#[tokio::main]
+async fn create_test_bucket_sync(name: &str) -> Bucket {
+    create_test_bucket(name).await
+}
+
+// since all tests run in parallel, we need to make sure we do not create multiple buckets with
+// the same name in each test.
+#[cfg(test)]
+async fn create_test_bucket(name: &str) -> Bucket {
+    std::thread::sleep(std::time::Duration::from_millis(1500)); // avoid getting rate limited
+
+    dotenv::dotenv().ok();
+    let base_name = std::env::var("TEST_BUCKET").unwrap();
+    let name = format!("{}-{}", base_name, name);
+    let new_bucket = NewBucket {
+        name,
+        ..NewBucket::default()
+    };
+    match Bucket::create(&new_bucket).await {
+        Ok(bucket) => bucket,
+        Err(_alread_exists) => Bucket::read(&new_bucket.name).await.unwrap(),
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/bucket.rs
+++ b/vendor/cloud-storage-rs/src/resources/bucket.rs
@@ -1,0 +1,1140 @@
+use crate::error::{Error, GoogleResponse};
+use crate::resources::bucket_access_control::{BucketAccessControl, NewBucketAccessControl};
+pub use crate::resources::common::Entity;
+use crate::resources::common::ListResponse;
+use crate::resources::default_object_access_control::{
+    DefaultObjectAccessControl, NewDefaultObjectAccessControl,
+};
+pub use crate::resources::location::*;
+
+/// The Buckets resource represents a
+/// [bucket](https://cloud.google.com/storage/docs/key-terms#buckets) in Google Cloud Storage. There
+/// is a single global namespace shared by all buckets. For more information, see
+/// [Bucket Name Requirements](https://cloud.google.com/storage/docs/naming#requirements).
+///
+/// Buckets contain objects which can be accessed by their own methods. In addition to the
+/// [ACL property](https://cloud.google.com/storage/docs/access-control/lists), buckets contain
+/// `BucketAccessControls`, for use in fine-grained manipulation of an existing bucket's access
+/// controls.
+///
+/// A bucket is always owned by the project team owners group.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Bucket {
+    /// The kind of item this is. For buckets, this is always `storage#bucket`.
+    pub kind: String,
+    /// The ID of the bucket. For buckets, the `id` and `name` properties are the same.
+    pub id: String, // should be u64, mumble mumble
+    /// The URI of this bucket.
+    pub self_link: String,
+    /// The project number of the project the bucket belongs to.
+    #[serde(deserialize_with = "crate::from_str")]
+    pub project_number: u64,
+    /// The name of the bucket.
+    pub name: String,
+    /// The creation time of the bucket in RFC 3339 format.
+    pub time_created: chrono::DateTime<chrono::Utc>,
+    /// The modification time of the bucket in RFC 3339 format.
+    pub updated: chrono::DateTime<chrono::Utc>,
+    /// Whether or not to automatically apply an eventBasedHold to new objects added to the bucket.
+    pub default_event_based_hold: Option<bool>,
+    /// The bucket's retention policy, which defines the minimum age an object in the bucket must
+    /// reach before it can be deleted or overwritten.
+    pub retention_policy: Option<RetentionPolicy>,
+    /// The metadata generation of this bucket.
+    #[serde(deserialize_with = "crate::from_str")]
+    pub metageneration: i64,
+    /// Access controls on the bucket, containing one or more bucketAccessControls Resources. If
+    /// iamConfiguration.uniformBucketLevelAccess.enabled is set to true, this field is omitted in
+    /// responses, and requests that specify this field fail with a 400 Bad Request response.
+    pub acl: Option<Vec<BucketAccessControl>>,
+    /// Default access controls to apply to new objects when no ACL is provided. This list contains
+    /// one or more defaultObjectAccessControls Resources. If
+    /// iamConfiguration.uniformBucketLevelAccess.enabled is set to true, this field is omitted in
+    /// responses, and requests that specify this field fail.
+    pub default_object_acl: Option<Vec<DefaultObjectAccessControl>>,
+    /// The bucket's IAM configuration.
+    pub iam_configuration: IamConfiguration,
+    /// Encryption configuration for a bucket.
+    pub encryption: Option<Encryption>,
+    /// The owner of the bucket. This is always the project team's owner group.
+    pub owner: Option<Owner>,
+    /// The location of the bucket. Object data for objects in the bucket resides in physical
+    /// storage within this region. Defaults to US. See Cloud Storage bucket locations for the
+    /// authoritative list.
+    pub location: Location,
+    /// The type of location that the bucket resides in, as determined by the location property.
+    pub location_type: String,
+    /// The bucket's website configuration, controlling how the service behaves when accessing
+    /// bucket contents as a web site. See the Static Website Examples for more information.
+    pub website: Option<Website>,
+    /// The bucket's logging configuration, which defines the destination bucket and optional name
+    /// prefix for the current bucket's logs.
+    pub logging: Option<Logging>,
+    /// The bucket's versioning configuration.
+    pub versioning: Option<Versioning>,
+    /// The bucket's Cross-Origin Resource Sharing (CORS) configuration.
+    pub cors: Option<Vec<Cors>>,
+    /// The bucket's lifecycle configuration. See
+    /// [lifecycle management](https://cloud.google.com/storage/docs/lifecycle) for more
+    /// information.
+    pub lifecycle: Option<Lifecycle>,
+    /// User-provided bucket labels, in key/value pairs.
+    pub labels: Option<std::collections::HashMap<String, String>>,
+    /// The bucket's default storage class, used whenever no storageClass is specified for a
+    /// newly-created object. If storageClass is not specified when the bucket
+    /// is created, it defaults to STANDARD. For more information, see storage classes.
+    pub storage_class: StorageClass,
+    /// The bucket's billing configuration.
+    pub billing: Option<Billing>,
+    /// HTTP 1.1 [Entity tag](https://tools.ietf.org/html/rfc7232#section-2.3) for the bucket.
+    pub etag: String,
+}
+
+/// A model that can be used to insert new buckets into Google Cloud Storage.
+#[derive(Debug, PartialEq, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewBucket {
+    /// The name of the bucket. See the bucket naming guidelines for more information.
+    pub name: String,
+    /// Whether or not to automatically apply an eventBasedHold to new objects added to the bucket.
+    pub default_event_based_hold: Option<bool>,
+    /// Access controls on the bucket, containing one or more `BucketAccessControls` resources. If
+    /// `iamConfiguration.uniformBucketLevelAccess.enabled` is set to true, this field is omitted in
+    /// responses, and requests that specify this field fail with a `400 Bad Request` response.
+    pub acl: Option<Vec<NewBucketAccessControl>>,
+    /// Default access controls to apply to new objects when no ACL is provided. This list defines
+    /// an entity and role for one or more `DefaultObjectAccessControls` resources. If
+    /// `iamConfiguration.uniformBucketLevelAccess.enabled` is set to true, this field is omitted in
+    /// responses, and requests that specify this field fail with a `400 Bad Request` response.
+    pub default_object_acl: Option<Vec<NewDefaultObjectAccessControl>>,
+    /// The bucket's IAM configuration.
+    pub iam_configuration: Option<IamConfiguration>,
+    /// Encryption configuration for a bucket.
+    pub encryption: Option<Encryption>,
+    /// The location of the bucket. Object data for objects in the bucket resides in physical
+    /// storage within this region. Defaults to US. See Cloud Storage bucket locations for the
+    /// authoritative list.
+    pub location: Location,
+    /// The bucket's website configuration, controlling how the service behaves when accessing
+    /// bucket contents as a web site. See the Static Website Examples for more information.
+    pub website: Option<Website>,
+    /// The bucket's logging configuration, which defines the destination bucket and optional name
+    /// prefix for the current bucket's logs.
+    pub logging: Option<Logging>,
+    /// The bucket's versioning configuration.
+    pub versioning: Option<Versioning>,
+    /// The bucket's Cross-Origin Resource Sharing (CORS) configuration.
+    pub cors: Option<Vec<Cors>>,
+    /// The bucket's lifecycle configuration. See
+    /// [lifecycle management](https://cloud.google.com/storage/docs/lifecycle) for more
+    /// information.
+    pub lifecycle: Option<Lifecycle>,
+    /// User-provided bucket labels, in key/value pairs.
+    pub labels: Option<std::collections::HashMap<String, String>>,
+    /// The bucket's default storage class, used whenever no storageClass is specified for a
+    /// newly-created object. If storageClass is not specified when the bucket
+    /// is created, it defaults to STANDARD. For more information, see storage classes.
+    pub storage_class: Option<StorageClass>,
+    /// The bucket's billing configuration.
+    pub billing: Option<Billing>,
+}
+
+/// Contains information about how files are kept after deletion.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RetentionPolicy {
+    /// The period of time, in seconds, that objects in the bucket must be retained and cannot be
+    /// deleted, overwritten, or made noncurrent. The value must be greater than 0 seconds and less
+    /// than 3,155,760,000 seconds.
+    #[serde(deserialize_with = "crate::from_str")]
+    pub retention_period: u64,
+    /// The time from which the retentionPolicy was effective, in RFC 3339 format.
+    pub effective_time: chrono::DateTime<chrono::Utc>,
+    /// Whether or not the retentionPolicy is locked. If true, the retentionPolicy cannot be removed
+    /// and the retention period cannot be reduced.
+    pub is_locked: Option<bool>,
+}
+
+/// Contains information about the Buckets IAM configuration.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IamConfiguration {
+    /// The bucket's uniform bucket-level access configuration.
+    ///
+    /// Note: iamConfiguration also includes the bucketPolicyOnly field, which uses a legacy name
+    /// but has the same functionality as the uniformBucketLevelAccess field. We recommend only
+    /// using uniformBucketLevelAccess, as specifying both fields may result in unreliable behavior.
+    pub uniform_bucket_level_access: UniformBucketLevelAccess,
+}
+
+/// Access that is configured for all objects in one go.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UniformBucketLevelAccess {
+    /// Whether or not the bucket uses uniform bucket-level access. If set, access checks only use
+    /// bucket-level IAM policies or above.
+    pub enabled: bool,
+    /// The deadline time for changing iamConfiguration.uniformBucketLevelAccess.enabled from true
+    /// to false, in RFC 3339 format.
+    ///
+    /// iamConfiguration.uniformBucketLevelAccess.enabled may be changed from true to false until
+    /// the locked time, after which the field is immutable.
+    pub locked_time: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Contains information about the encryption used for data in this Bucket.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Encryption {
+    /// A Cloud KMS key that will be used to encrypt objects inserted into this bucket, if no
+    /// encryption method is specified.
+    pub default_kms_key_name: String,
+}
+
+/// Contains information about an entity that is able to own a `Bucket`.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Owner {
+    /// The entity, in the form project-owner-projectId.
+    pub entity: Entity,
+    /// The ID for the entity.
+    pub entity_id: Option<String>,
+}
+
+/// Contains configuration about how to visit the website linked to this Bucket.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Website {
+    /// If the requested object path is missing, the service will ensure the path has a trailing
+    /// '/', append this suffix, and attempt to retrieve the resulting object. This allows the
+    /// creation of index.html objects to represent directory pages.
+    pub main_page_suffix: String,
+    /// If the requested object path is missing, and any mainPageSuffix object is missing, if
+    /// applicable, the service will return the named object from this bucket as the content for a
+    /// 404 Not Found result.
+    pub not_found_page: String,
+}
+
+/// Contains information of where and how access logs to this bucket are maintained.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Logging {
+    /// The destination bucket where the current bucket's logs should be placed.
+    pub log_bucket: String,
+    /// A prefix for log object names. The default prefix is the bucket name.
+    pub log_object_prefix: String,
+}
+
+/// Contains information about whether a Bucket keeps track of its version.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Versioning {
+    /// While set to true, versioning is fully enabled for this bucket.
+    pub enabled: bool,
+}
+
+/// Contains information about how OPTIONS requests for this Bucket are handled.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cors {
+    /// The list of Origins eligible to receive CORS response headers. Note: "*" is permitted in the
+    /// list of origins, and means "any Origin".
+    pub origin: Vec<String>,
+    /// The list of HTTP methods on which to include CORS response headers, (GET, OPTIONS, POST,
+    /// etc) Note: "*" is permitted in the list of methods, and means "any method".
+    pub method: Vec<String>,
+    /// The list of HTTP headers other than the simple response headers to give permission for the
+    /// user-agent to share across domains.
+    pub response_header: Vec<String>,
+    /// The value, in seconds, to return in the Access-Control-Max-Age header used in preflight
+    /// responses.
+    #[serde(deserialize_with = "crate::from_str")]
+    pub max_age_seconds: i32,
+}
+
+/// Contains a set of `Rule` Objects which together describe the way this lifecycle behaves
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Lifecycle {
+    /// A lifecycle management rule, which is made of an action to take and the condition(s) under
+    /// which the action will be taken.
+    pub rule: Vec<Rule>,
+}
+
+/// An element of the lifecyle list.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Rule {
+    /// The action to take.
+    pub action: Action,
+    /// The condition(s) under which the action will be taken.
+    pub condition: Condition,
+}
+
+/// Represents an action that might be undertaken due to a `Condition`.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Action {
+    /// Type of the action.
+    pub r#type: ActionType,
+    /// Target storage class. Required iff the type of the action is SetStorageClass.
+    pub storage_class: Option<StorageClass>,
+}
+
+/// Type of the action.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum ActionType {
+    /// Deletes a Bucket.
+    Delete,
+    /// Sets the `storage_class` of a Bucket.
+    SetStorageClass,
+}
+
+/// A rule that might induce an `Action` if met.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Condition {
+    /// Age of an object (in days). This condition is satisfied when an object reaches the specified
+    /// age.
+    pub age: Option<i32>,
+    /// A date in `RFC 3339` format with only the date part (for instance, "2013-01-15"). This
+    /// condition is satisfied when an object is created before midnight of the specified date in
+    /// UTC.
+    pub created_before: Option<chrono::DateTime<chrono::Utc>>,
+    /// Relevant only for versioned objects. If the value is true, this condition matches the live
+    /// version of objects; if the value is `false`, it matches noncurrent versions of objects.
+    pub is_live: Option<bool>,
+    /// Objects having any of the storage classes specified by this condition will be matched.
+    /// Values include STANDARD, NEARLINE, COLDLINE, MULTI_REGIONAL, REGIONAL, and
+    /// DURABLE_REDUCED_AVAILABILITY.
+    pub matches_storage_class: Option<Vec<String>>,
+    /// Relevant only for versioned objects. If the value is N, this condition is satisfied when
+    /// there are at least N versions (including the live version) newer than this version of the
+    /// object.
+    #[serde(default, deserialize_with = "crate::from_str_opt")]
+    pub num_newer_versions: Option<i32>,
+}
+
+/// Contains information about the payment structure of this bucket
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Billing {
+    /// When set to true, Requester Pays is enabled for this bucket.
+    pub requester_pays: bool,
+}
+
+/// The type of storage that is used. Pertains to availability, performance and cost.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum StorageClass {
+    /// Standard Storage is best for data that is frequently accessed ("hot" data) and/or stored for
+    /// only brief periods of time.
+    Standard,
+    /// Nearline Storage is a low-cost, highly durable storage service for storing infrequently
+    /// accessed data.
+    Nearline,
+    /// Coldline Storage is a very-low-cost, highly durable storage service for data archiving,
+    /// online backup, and disaster recovery.
+    Coldline,
+    /// Equivalent to Standard Storage, except Multi-Regional Storage can only be used for objects
+    /// stored in multi-regions or dual-regions.
+    MultiRegional,
+    /// Equivalent to Standard Storage, except Regional Storage can only be used for objects stored
+    /// in regions.
+    Regional,
+    /// Similar to Standard Storage except:
+    ///
+    /// DRA has higher pricing for operations.
+    /// DRA has lower performance, particularly in terms of availability (DRA has a 99% availability
+    /// SLA).
+    ///
+    /// You can move your data from DRA to other storage classes by performing a storage transfer.
+    DurableReducedAvailability,
+}
+
+/// A representation of the IAM Policiy for a certain bucket.
+#[derive(Debug, PartialEq, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IamPolicy {
+    /// The [Cloud IAM policy](https://cloud.google.com/iam/docs/policies#versions) version.
+    pub version: i32,
+    /// The kind of item this is. For policies, this field is ignored in a request and is
+    /// `storage#policy` in a response.
+    pub kind: Option<String>,
+    /// The ID of the resource to which this policy belongs. The response for this field is of the
+    /// form `projects/_/buckets/bucket`. This field is ignored in a request.
+    pub resource_id: Option<String>,
+    /// A list of the bindings for this policy.
+    pub bindings: Vec<Binding>,
+    /// HTTP 1.1 [Entity tag](https://tools.ietf.org/html/rfc7232#section-2.3) for this policy.
+    pub etag: String,
+}
+
+/// An association between a role, which comes with a set of permissions, and members who may assume
+/// that role.
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Binding {
+    /// The role to which members belong. Two types of roles are supported: standard IAM roles,
+    /// which grant permissions that do not map directly to those provided by ACLs, and legacy IAM
+    /// roles, which do map directly to ACL permissions. All roles are of the format
+    /// `roles/storage.specificRole.`
+    ///
+    /// See
+    /// [Cloud Storage IAM Roles](https://cloud.google.com/storage/docs/access-control/iam-roles)
+    /// for a list of available roles.
+    pub role: IamRole,
+    /// A collection of identifiers for members who may assume the provided role. Recognized
+    /// identifiers are as follows:
+    ///
+    /// * `allUsers` — A special identifier that represents anyone on the internet; with or without
+    ///   a Google account.
+    /// * `allAuthenticatedUsers` — A special identifier that represents anyone who is authenticated
+    ///   with a Google account or a service account.
+    /// * `user:emailid` — An email address that represents a specific account. For example,
+    ///   user:alice@gmail.com or user:joe@example.com.
+    /// * `serviceAccount:emailid` — An email address that represents a service account. For
+    ///   example, serviceAccount:my-other-app@appspot.gserviceaccount.com .
+    /// * `group:emailid` — An email address that represents a Google group. For example,
+    ///   group:admins@example.com.
+    /// * `domain:domain` — A G Suite domain name that represents all the users of that domain. For
+    ///   example, domain:google.com or domain:example.com.
+    /// * `projectOwner:projectid` — Owners of the given project. For example,
+    ///   projectOwner:my-example-project
+    /// * `projectEditor:projectid` — Editors of the given project. For example,
+    ///   projectEditor:my-example-project
+    /// * `projectViewer:projectid` — Viewers of the given project. For example,
+    ///   projectViewer:my-example-project
+    pub members: Vec<String>,
+    /// A condition object associated with this binding. Each role binding can only contain one
+    /// condition.
+    pub condition: Option<IamCondition>,
+}
+
+/// A condition object associated with a binding.
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IamCondition {
+    /// Title of the condition. For example, "expires_end_of_2018".
+    pub title: String,
+    /// Optional description of the condition. For example, "Expires at midnight on 2018-12-31".
+    pub description: Option<String>,
+    /// [Attribute-based](https://cloud.google.com/iam/docs/conditions-overview#attributes) logic
+    /// expression using a subset of the Common Expression Language (CEL). For example,
+    /// "request.time < timestamp('2019-01-01T00:00:00Z')".
+    pub expression: String,
+}
+
+/// All possible roles that can exist in the IAM system. For a more comprehensive version, check
+/// [Googles Documentation](https://cloud.google.com/storage/docs/access-control/iam-roles).
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(untagged)]
+pub enum IamRole {
+    /// Standard roles can be applied to either buckets or projects.
+    Standard(StandardIamRole),
+    /// Primitive roles are roles that must be added on a per-project basis.
+    Primitive(PrimitiveIamRole),
+    /// Legacy roles are roles that can only be added to an individual bucket.
+    Legacy(LegacyIamRole),
+}
+
+/// The following enum contains Cloud Identity and Access Management (Cloud IAM) roles that are
+/// associated with Cloud Storage and lists the permissions that are contained in each role. Unless
+/// otherwise noted, these roles can be applied either to entire projects or specific buckets.
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub enum StandardIamRole {
+    /// Allows users to create objects. Does not give permission to view, delete, or overwrite
+    /// objects.
+    #[serde(rename = "roles/storage.objectCreator")]
+    ObjectCreator,
+    /// Grants access to view objects and their metadata, excluding ACLs.
+    ///
+    /// Can also list the objects in a bucket.
+    #[serde(rename = "roles/storage.objectViewer")]
+    ObjectViewer,
+    /// Grants full control over objects, including listing, creating, viewing, and deleting
+    /// objects.
+    #[serde(rename = "roles/storage.objectAdmin")]
+    ObjectAdmin,
+    /// Full control over HMAC keys in a project.
+    #[serde(rename = "roles/storage.hmacKeyAdmin")]
+    HmacKeyAdmin,
+    /// Grants full control of buckets and objects.
+    ///
+    /// When applied to an individual bucket, control applies only to the specified bucket and
+    /// objects within the bucket.
+    #[serde(rename = "roles/storage.admin")]
+    Admin,
+}
+
+/// The following enum contains primitive roles and the Cloud Storage permissions that these roles
+/// contain. Primitive roles cannot be added at the bucket-level.
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub enum PrimitiveIamRole {
+    /// Grants permission to list buckets as well as view bucket metadata, excluding ACLs, when
+    /// listing. Also grants permission to list and get HMAC keys in the project.
+    #[serde(rename = "role/viewer")]
+    Viewer,
+    /// Grants permission to create, list, and delete buckets. Grants permission to view bucket
+    /// metadata, excluding ACLs, when listing. Grants full control over HMAC keys in a project.
+    #[serde(rename = "role/editor")]
+    Editor,
+    /// Grants permission to create, list, and delete buckets. Also grants permission to view bucket
+    /// metadata, excluding ACLs, when listing. Grants full control over HMAC keys in a project.
+    #[serde(rename = "role/owner")]
+    Owner,
+}
+
+/// The following enum contains Cloud IAM roles that are equivalent to Access Control List (ACL)
+/// permissions. These Cloud IAM roles can only be applied to a bucket, not a project.
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub enum LegacyIamRole {
+    /// Grants permission to view objects and their metadata, excluding ACLs.
+    #[serde(rename = "roles/storage.legacyObjectReader")]
+    LegacyObjectReader,
+    /// Grants permission to view and edit objects and their metadata, including ACLs.
+    #[serde(rename = "roles/storage.legacyObjectOwner")]
+    LegacyObjectOwner,
+    /// Grants permission to list a bucket's contents and read bucket metadata, excluding Cloud IAM
+    /// policies. Also grants permission to read object metadata, excluding Cloud IAM policies, when
+    /// listing objects.
+    ///
+    /// Use of this role is also reflected in the bucket's ACLs. See
+    /// [Cloud IAM relation to ACLs](https://cloud.google.com/storage/docs/access-control/iam#acls)
+    /// for  more information.
+    #[serde(rename = "roles/storage.legacyBucketReader")]
+    LegacyBucketReader,
+    /// Grants permission to create, overwrite, and delete objects; list objects in a bucket and
+    /// read object metadata, excluding Cloud IAM policies, when listing; and read bucket metadata,
+    /// excluding Cloud IAM policies.
+    ///
+    /// Use of this role is also reflected in the bucket's ACLs. See
+    /// [Cloud IAM relation to ACLs](https://cloud.google.com/storage/docs/access-control/iam#acls)
+    /// for  more information.
+    #[serde(rename = "roles/storage.legacyBucketWriter")]
+    LegacyBucketWriter,
+    /// Grants permission to create, overwrite, and delete objects; list objects in a bucket and
+    /// read object metadata, excluding Cloud IAM policies, when listing; and read and edit bucket
+    /// metadata, including Cloud IAM policies.
+    ///
+    /// Use of this role is also reflected in the bucket's ACLs. See
+    /// [Cloud IAM relation to ACLs](https://cloud.google.com/storage/docs/access-control/iam#acls)
+    /// for  more information.
+    #[serde(rename = "roles/storage.legacyBucketOwner")]
+    LegacyBucketOwner,
+}
+
+/// The request needed to perform the Object::test_iam_permission function.
+#[derive(Debug, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestIamPermission {
+    /// The kind of item this is.
+    kind: String,
+    /// The permissions held by the caller. Permissions are always of the format
+    /// `storage.resource.capability`, where resource is one of buckets or objects. See
+    /// [Cloud Storage IAM Permissions]
+    /// (https://cloud.google.com/storage/docs/access-control/iam-permissions) for a list of
+    /// supported permissions.
+    permissions: Vec<String>,
+}
+
+impl Bucket {
+    /// Creates a new `Bucket`. There are many options that you can provide for creating a new
+    /// bucket, so the `NewBucket` resource contains all of them. Note that `NewBucket` implements
+    /// `Default`, so you don't have to specify the fields you're not using. And error is returned
+    /// if that bucket name is already taken.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::bucket::{Bucket, NewBucket};
+    /// use cloud_storage::bucket::{Location, MultiRegion};
+    ///
+    /// let new_bucket = NewBucket {
+    ///    name: "cloud-storage-rs-doc-1".to_string(), // this is the only mandatory field
+    ///    location: Location::Multi(MultiRegion::Eu),
+    ///    ..Default::default()
+    /// };
+    /// let bucket = Bucket::create(&new_bucket).await?;
+    /// # bucket.delete().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(new_bucket: &NewBucket) -> crate::Result<Self> {
+        let url = format!("{}/b/", crate::BASE_URL);
+        let project = &crate::SERVICE_ACCOUNT.project_id;
+        let query = [("project", project)];
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .post(&url)
+            .headers(crate::get_headers().await?)
+            .query(&query)
+            .json(new_bucket)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Bucket::create`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn create_sync(new_bucket: &NewBucket) -> crate::Result<Self> {
+        Self::create(new_bucket).await
+    }
+
+    /// Returns all `Bucket`s within this project.
+    ///
+    /// ### Note
+    /// When using incorrect permissions, this function fails silently and returns an empty list.
+    ///
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Bucket;
+    ///
+    /// let buckets = Bucket::list().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list() -> Result<Vec<Self>, Error> {
+        let url = format!("{}/b/", crate::BASE_URL);
+        let project = &crate::SERVICE_ACCOUNT.project_id;
+        let query = [("project", project)];
+        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .query(&query)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.items),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Bucket::list`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn list_sync() -> Result<Vec<Self>, Error> {
+        Self::list().await
+    }
+
+    /// Returns a single `Bucket` by its name. If the Bucket does not exist, an error is returned.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Bucket;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-2".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = Bucket::create(&new_bucket).await?;
+    ///
+    /// let bucket = Bucket::read("cloud-storage-rs-doc-2").await?;
+    /// # bucket.delete().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(name: &str) -> crate::Result<Self> {
+        let url = format!("{}/b/{}", crate::BASE_URL, name);
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Bucket::read`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn read_sync(name: &str) -> crate::Result<Self> {
+        Self::read(name).await
+    }
+
+    /// Update an existing `Bucket`. If you declare you bucket as mutable, you can edit its fields.
+    /// You can then flush your changes to Google Cloud Storage using this method.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::bucket::{Bucket, RetentionPolicy};
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-3".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = Bucket::create(&new_bucket).await?;
+    ///
+    /// let mut bucket = Bucket::read("cloud-storage-rs-doc-3").await?;
+    /// bucket.retention_policy = Some(RetentionPolicy {
+    ///     retention_period: 50,
+    ///     effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+    ///     is_locked: Some(false),
+    /// });
+    /// bucket.update().await?;
+    /// # bucket.delete().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(&self) -> crate::Result<Self> {
+        let url = format!("{}/b/{}", crate::BASE_URL, self.name);
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .put(&url)
+            .headers(crate::get_headers().await?)
+            .json(self)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Bucket::update`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn update_sync(&self) -> crate::Result<Self> {
+        self.update().await
+    }
+
+    /// Delete an existing `Bucket`. This permanently removes a bucket from Google Cloud Storage.
+    /// An error is returned when you don't have sufficient permissions, or when the
+    /// `retention_policy` prevents you from deleting your Bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Bucket;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "unnecessary-bucket".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = Bucket::create(&new_bucket).await?;
+    ///
+    /// let bucket = Bucket::read("unnecessary-bucket").await?;
+    /// bucket.delete().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(self) -> crate::Result<()> {
+        let url = format!("{}/b/{}", crate::BASE_URL, self.name);
+        let response = reqwest::Client::new()
+            .delete(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(Error::Google(response.json().await?))
+        }
+    }
+
+    /// The synchronous equivalent of `Bucket::delete`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn delete_sync(self) -> crate::Result<()> {
+        self.delete().await
+    }
+
+    /// Returns the [IAM Policy](https://cloud.google.com/iam/docs/) for this bucket.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Bucket;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-4".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = Bucket::create(&new_bucket).await?;
+    ///
+    /// let bucket = Bucket::read("cloud-storage-rs-doc-4").await?;
+    /// let policy = bucket.get_iam_policy().await?;
+    /// # bucket.delete().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_iam_policy(&self) -> crate::Result<IamPolicy> {
+        let url = format!("{}/b/{}/iam", crate::BASE_URL, self.name);
+        let result: GoogleResponse<IamPolicy> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Bucket::get_iam_policy`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn get_iam_policy_sync(&self) -> crate::Result<IamPolicy> {
+        self.get_iam_policy().await
+    }
+
+    /// Updates the [IAM Policy](https://cloud.google.com/iam/docs/) for this bucket.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Bucket;
+    /// use cloud_storage::bucket::{IamPolicy, Binding, IamRole, StandardIamRole, Entity};
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-5".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = Bucket::create(&new_bucket).await?;
+    ///
+    /// let bucket = Bucket::read("cloud-storage-rs-doc-5").await?;
+    /// let iam_policy = IamPolicy {
+    ///     version: 1,
+    ///     bindings: vec![
+    ///         Binding {
+    ///             role: IamRole::Standard(StandardIamRole::ObjectViewer),
+    ///             members: vec!["allUsers".to_string()],
+    ///             condition: None,
+    ///         }
+    ///     ],
+    ///     ..Default::default()
+    /// };
+    /// let policy = bucket.set_iam_policy(&iam_policy).await?;
+    /// # bucket.delete().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn set_iam_policy(&self, iam: &IamPolicy) -> crate::Result<IamPolicy> {
+        let url = format!("{}/b/{}/iam", crate::BASE_URL, self.name);
+        let result: GoogleResponse<IamPolicy> = reqwest::Client::new()
+            .put(&url)
+            .headers(crate::get_headers().await?)
+            .json(iam)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Bucket::set_iam_policy`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn set_iam_policy_sync(&self, iam: &IamPolicy) -> crate::Result<IamPolicy> {
+        self.set_iam_policy(iam).await
+    }
+
+    /// Checks whether the user provided in the service account has this permission.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Bucket;
+    ///
+    /// let bucket = Bucket::read("my-bucket").await?;
+    /// bucket.test_iam_permission("storage.buckets.get").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn test_iam_permission(&self, permission: &str) -> crate::Result<TestIamPermission> {
+        if permission == "storage.buckets.list" || permission == "storage.buckets.create" {
+            return Err(Error::new(
+                "tested permission must not be `storage.buckets.list` or `storage.buckets.create`",
+            ));
+        }
+        let url = format!("{}/b/{}/iam/testPermissions", crate::BASE_URL, self.name);
+        let result: GoogleResponse<TestIamPermission> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .query(&[("permissions", permission)])
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Bucket::test_iam_policy`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn test_iam_permission_sync(
+        &self,
+        permission: &str,
+    ) -> crate::Result<TestIamPermission> {
+        self.test_iam_permission(permission).await
+    }
+
+    fn _lock_retention_policy() {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resources::common::Role;
+
+    #[tokio::test]
+    async fn create() -> Result<(), Box<dyn std::error::Error>> {
+        dotenv::dotenv().ok();
+        let base_name = std::env::var("TEST_BUCKET")?;
+        // use a more complex bucket in this test.
+        let new_bucket = NewBucket {
+            name: format!("{}-test-create", base_name),
+            default_event_based_hold: Some(true),
+            acl: Some(vec![NewBucketAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            }]),
+            default_object_acl: Some(vec![NewDefaultObjectAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            }]),
+            iam_configuration: Some(IamConfiguration {
+                uniform_bucket_level_access: UniformBucketLevelAccess {
+                    enabled: false,
+                    locked_time: None,
+                },
+            }),
+            ..Default::default()
+        };
+        let bucket = Bucket::create(&new_bucket).await?;
+        bucket.delete().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list() -> Result<(), Box<dyn std::error::Error>> {
+        Bucket::list().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn read() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::create_test_bucket("test-read").await;
+        let also_bucket = Bucket::read(&bucket.name).await?;
+        assert_eq!(bucket, also_bucket);
+        bucket.delete().await?;
+        assert!(also_bucket.delete().await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update() -> Result<(), Box<dyn std::error::Error>> {
+        let mut bucket = crate::create_test_bucket("test-update").await;
+        bucket.retention_policy = Some(RetentionPolicy {
+            retention_period: 50,
+            effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+            is_locked: Some(false),
+        });
+        bucket.update().await?;
+        let updated = Bucket::read(&bucket.name).await?;
+        assert_eq!(updated.retention_policy.unwrap().retention_period, 50);
+        bucket.delete().await?;
+        Ok(())
+    }
+
+    // used a lot throughout the other tests, but included for completeness
+    #[tokio::test]
+    async fn delete() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::create_test_bucket("test-delete").await;
+        bucket.delete().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_iam_policy() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::create_test_bucket("test-get-iam-policy").await;
+        bucket.get_iam_policy().await?;
+        bucket.delete().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_iam_policy() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::create_test_bucket("test-set-iam-policy").await;
+        let iam_policy = IamPolicy {
+            bindings: vec![Binding {
+                role: IamRole::Standard(StandardIamRole::ObjectViewer),
+                members: vec!["allUsers".to_string()],
+                condition: None,
+            }],
+            ..Default::default()
+        };
+        bucket.set_iam_policy(&iam_policy).await?;
+        assert_eq!(bucket.get_iam_policy().await?.bindings, iam_policy.bindings);
+        bucket.delete().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_iam_permission() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::create_test_bucket("test-test-ia-permission").await;
+        bucket.test_iam_permission("storage.buckets.get").await?;
+        bucket.delete().await?;
+        Ok(())
+    }
+
+    #[cfg(feature = "sync")]
+    mod sync {
+        use super::*;
+        use crate::resources::common::Role;
+
+        #[test]
+        fn create() -> Result<(), Box<dyn std::error::Error>> {
+            dotenv::dotenv().ok();
+            let base_name = std::env::var("TEST_BUCKET")?;
+            // use a more complex bucket in this test.
+            let new_bucket = NewBucket {
+                name: format!("{}-test-create", base_name),
+                default_event_based_hold: Some(true),
+                acl: Some(vec![NewBucketAccessControl {
+                    entity: Entity::AllUsers,
+                    role: Role::Reader,
+                }]),
+                default_object_acl: Some(vec![NewDefaultObjectAccessControl {
+                    entity: Entity::AllUsers,
+                    role: Role::Reader,
+                }]),
+                iam_configuration: Some(IamConfiguration {
+                    uniform_bucket_level_access: UniformBucketLevelAccess {
+                        enabled: false,
+                        locked_time: None,
+                    },
+                }),
+                ..Default::default()
+            };
+            let bucket = Bucket::create_sync(&new_bucket)?;
+            bucket.delete_sync()?;
+            Ok(())
+        }
+
+        #[test]
+        fn list() -> Result<(), Box<dyn std::error::Error>> {
+            Bucket::list_sync()?;
+            Ok(())
+        }
+
+        #[test]
+        fn read() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::create_test_bucket_sync("test-read");
+            let also_bucket = Bucket::read_sync(&bucket.name)?;
+            assert_eq!(bucket, also_bucket);
+            bucket.delete_sync()?;
+            assert!(also_bucket.delete_sync().is_err());
+            Ok(())
+        }
+
+        #[test]
+        fn update() -> Result<(), Box<dyn std::error::Error>> {
+            let mut bucket = crate::create_test_bucket_sync("test-update");
+            bucket.retention_policy = Some(RetentionPolicy {
+                retention_period: 50,
+                effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+                is_locked: Some(false),
+            });
+            bucket.update_sync()?;
+            let updated = Bucket::read_sync(&bucket.name)?;
+            assert_eq!(updated.retention_policy.unwrap().retention_period, 50);
+            bucket.delete_sync()?;
+            Ok(())
+        }
+
+        // used a lot throughout the other tests, but included for completeness
+        #[test]
+        fn delete() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::create_test_bucket_sync("test-delete");
+            bucket.delete_sync()?;
+            Ok(())
+        }
+
+        #[test]
+        fn get_iam_policy() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::create_test_bucket_sync("test-get-iam-policy");
+            bucket.get_iam_policy_sync()?;
+            bucket.delete_sync()?;
+            Ok(())
+        }
+
+        #[test]
+        fn set_iam_policy() -> Result<(), Box<dyn std::error::Error>> {
+            // use crate::resources::iam_policy::{Binding, IamRole, StandardIamRole};
+
+            let bucket = crate::create_test_bucket_sync("test-set-iam-policy");
+            let iam_policy = IamPolicy {
+                bindings: vec![Binding {
+                    role: IamRole::Standard(StandardIamRole::ObjectViewer),
+                    members: vec!["allUsers".to_string()],
+                    condition: None,
+                }],
+                ..Default::default()
+            };
+            bucket.set_iam_policy_sync(&iam_policy)?;
+            assert_eq!(bucket.get_iam_policy_sync()?.bindings, iam_policy.bindings);
+            bucket.delete_sync()?;
+            Ok(())
+        }
+
+        #[test]
+        fn test_iam_permission() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::create_test_bucket_sync("test-test-ia-permission");
+            bucket.test_iam_permission_sync("storage.buckets.get")?;
+            bucket.delete_sync()?;
+            Ok(())
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/bucket_access_control.rs
+++ b/vendor/cloud-storage-rs/src/resources/bucket_access_control.rs
@@ -1,0 +1,435 @@
+use crate::error::GoogleResponse;
+use crate::resources::common::ListResponse;
+pub use crate::resources::common::{Entity, ProjectTeam, Role};
+
+/// The BucketAccessControl resource represents the Access Control Lists (ACLs) for buckets within
+/// Google Cloud Storage. ACLs let you specify who has access to your data and to what extent.
+///
+/// ```text,ignore
+/// Important: This method fails with a 400 Bad Request response for buckets with uniform
+/// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+/// control access instead.
+/// ```
+///
+/// There are three roles that can be assigned to an entity:
+///
+/// * READERs can get the bucket, though no acl property will be returned, and list the bucket's
+/// objects.
+/// * WRITERs are READERs, and they can insert objects into the bucket and delete the bucket's
+/// objects.
+/// * OWNERs are WRITERs, and they can get the acl property of a bucket, update a bucket, and call
+/// all BucketAccessControl methods on the bucket.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BucketAccessControl {
+    /// The kind of item this is. For bucket access control entries, this is always
+    /// `storage#bucketAccessControl`.
+    pub kind: String,
+    /// The ID of the access-control entry.
+    pub id: String,
+    /// The link to this access-control entry.
+    pub self_link: String,
+    /// The name of the bucket.
+    pub bucket: String,
+    /// The entity holding the permission, in one of the following forms:
+    ///
+    /// * `user-userId`
+    /// * `user-email`
+    /// * `group-groupId`
+    /// * `group-email`
+    /// * `domain-domain`
+    /// * `project-team-projectId`
+    /// * `allUsers`
+    /// * `allAuthenticatedUsers`
+    ///
+    /// Examples:
+    ///
+    /// * The user liz@example.com would be user-liz@example.com.
+    /// * The group example@googlegroups.com would be group-example@googlegroups.com.
+    /// * To refer to all members of the G Suite for Business domain example.com, the entity would
+    /// be domain-example.com.
+    pub entity: Entity,
+    /// The access permission for the entity.
+    pub role: Role,
+    /// The email address associated with the entity, if any.
+    pub email: Option<String>,
+    /// The ID for the entity, if any.
+    pub entity_id: Option<String>,
+    /// The domain associated with the entity, if any.
+    pub domain: Option<String>,
+    /// The project team associated with the entity, if any.
+    pub project_team: Option<ProjectTeam>,
+    /// HTTP 1.1 Entity tag for the access-control entry.
+    pub etag: String,
+}
+
+/// Model that can be used to create a new BucketAccessControl object.
+#[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewBucketAccessControl {
+    /// The entity holding the permission, in one of the following forms:
+    ///
+    /// * `user-userId`
+    /// * `user-email`
+    /// * `group-groupId`
+    /// * `group-email`
+    /// * `domain-domain`
+    /// * `project-team-projectId`
+    /// * `allUsers`
+    /// * `allAuthenticatedUsers`
+    ///
+    /// Examples:
+    ///
+    /// * The user liz@example.com would be user-liz@example.com.
+    /// * The group example@googlegroups.com would be group-example@googlegroups.com.
+    /// * To refer to all members of the G Suite for Business domain example.com, the entity would
+    /// be domain-example.com.
+    pub entity: Entity,
+    /// The access permission for the entity.
+    pub role: Role,
+}
+
+impl BucketAccessControl {
+    /// Create a new `BucketAccessControl` using the provided `NewBucketAccessControl`, related to
+    /// the `Bucket` provided by the `bucket_name` argument.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, NewBucketAccessControl};
+    /// use cloud_storage::bucket_access_control::{Role, Entity};
+    ///
+    /// let new_bucket_access_control = NewBucketAccessControl {
+    ///     entity: Entity::AllUsers,
+    ///     role: Role::Reader,
+    /// };
+    /// BucketAccessControl::create("mybucket", &new_bucket_access_control).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(
+        bucket: &str,
+        new_bucket_access_control: &NewBucketAccessControl,
+    ) -> crate::Result<Self> {
+        let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .post(&url)
+            .headers(crate::get_headers().await?)
+            .json(new_bucket_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `BucketAccessControl::create`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn create_sync(
+        bucket: &str,
+        new_bucket_access_control: &NewBucketAccessControl,
+    ) -> crate::Result<Self> {
+        Self::create(bucket, new_bucket_access_control).await
+    }
+
+    /// Returns all `BucketAccessControl`s related to this bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::bucket_access_control::BucketAccessControl;
+    ///
+    /// let acls = BucketAccessControl::list("mybucket").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
+        let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
+        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.items),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `BucketAccessControl::list`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn list_sync(bucket: &str) -> crate::Result<Vec<Self>> {
+        Self::list(bucket).await
+    }
+
+    /// Returns the ACL entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let controls = BucketAccessControl::read("mybucket", &Entity::AllUsers).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(bucket: &str, entity: &Entity) -> crate::Result<Self> {
+        let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, bucket, entity);
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `BucketAccessControl::read`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn read_sync(bucket: &str, entity: &Entity) -> crate::Result<Self> {
+        Self::read(bucket, entity).await
+    }
+
+    /// Update this `BucketAccessControl`.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let mut acl = BucketAccessControl::read("mybucket", &Entity::AllUsers).await?;
+    /// acl.entity = Entity::AllAuthenticatedUsers;
+    /// acl.update().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(&self) -> crate::Result<Self> {
+        let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, self.bucket, self.entity);
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .put(&url)
+            .headers(crate::get_headers().await?)
+            .json(self)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `BucketAccessControl::update`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn update_sync(&self) -> crate::Result<Self> {
+        self.update().await
+    }
+
+    /// Permanently deletes the ACL entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let controls = BucketAccessControl::read("mybucket", &Entity::AllUsers).await?;
+    /// controls.delete().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(self) -> crate::Result<()> {
+        let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, self.bucket, self.entity);
+        let response = reqwest::Client::new()
+            .delete(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+
+    /// The synchronous equivalent of `BucketAccessControl::delete`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn delete_sync(self) -> crate::Result<()> {
+        self.delete().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn create() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let new_bucket_access_control = NewBucketAccessControl {
+            entity: Entity::AllUsers,
+            role: Role::Reader,
+        };
+        BucketAccessControl::create(&bucket.name, &new_bucket_access_control).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        BucketAccessControl::list(&bucket.name).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn read() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        BucketAccessControl::read(&bucket.name, &Entity::AllUsers).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update() -> Result<(), Box<dyn std::error::Error>> {
+        // use a seperate bucket to prevent synchronization issues
+        let bucket = crate::create_test_bucket("test-update-bucket-access-controls").await;
+        let new_bucket_access_control = NewBucketAccessControl {
+            entity: Entity::AllUsers,
+            role: Role::Reader,
+        };
+        BucketAccessControl::create(&bucket.name, &new_bucket_access_control).await?;
+        let mut acl = BucketAccessControl::read(&bucket.name, &Entity::AllUsers).await?;
+        acl.entity = Entity::AllAuthenticatedUsers;
+        acl.update().await?;
+        bucket.delete().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete() -> Result<(), Box<dyn std::error::Error>> {
+        // use a seperate bucket to prevent synchronization issues
+        let bucket = crate::create_test_bucket("test-delete-bucket-access-controls").await;
+        let new_bucket_access_control = NewBucketAccessControl {
+            entity: Entity::AllUsers,
+            role: Role::Reader,
+        };
+        BucketAccessControl::create(&bucket.name, &new_bucket_access_control).await?;
+        let acl = BucketAccessControl::read(&bucket.name, &Entity::AllUsers).await?;
+        acl.delete().await?;
+        bucket.delete().await?;
+        Ok(())
+    }
+
+    #[cfg(feature = "sync")]
+    mod sync {
+        use super::*;
+
+        #[test]
+        fn create() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let new_bucket_access_control = NewBucketAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            BucketAccessControl::create_sync(&bucket.name, &new_bucket_access_control)?;
+            Ok(())
+        }
+
+        #[test]
+        fn list() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            BucketAccessControl::list_sync(&bucket.name)?;
+            Ok(())
+        }
+
+        #[test]
+        fn read() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            BucketAccessControl::read_sync(&bucket.name, &Entity::AllUsers)?;
+            Ok(())
+        }
+
+        #[test]
+        fn update() -> Result<(), Box<dyn std::error::Error>> {
+            // use a seperate bucket to prevent synchronization issues
+            let bucket = crate::create_test_bucket_sync("test-update-bucket-access-controls");
+            let new_bucket_access_control = NewBucketAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            BucketAccessControl::create_sync(&bucket.name, &new_bucket_access_control)?;
+            let mut acl = BucketAccessControl::read_sync(&bucket.name, &Entity::AllUsers)?;
+            acl.entity = Entity::AllAuthenticatedUsers;
+            acl.update_sync()?;
+            bucket.delete_sync()?;
+            Ok(())
+        }
+
+        #[test]
+        fn delete() -> Result<(), Box<dyn std::error::Error>> {
+            // use a seperate bucket to prevent synchronization issues
+            let bucket = crate::create_test_bucket_sync("test-delete-bucket-access-controls");
+            let new_bucket_access_control = NewBucketAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            BucketAccessControl::create_sync(&bucket.name, &new_bucket_access_control)?;
+            let acl = BucketAccessControl::read_sync(&bucket.name, &Entity::AllUsers)?;
+            acl.delete_sync()?;
+            bucket.delete_sync()?;
+            Ok(())
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/channel.rs
+++ b/vendor/cloud-storage-rs/src/resources/channel.rs
@@ -1,0 +1,31 @@
+
+
+pub struct Channel {
+    pub id: String,
+    pub resourceId: String,
+}
+
+impl Channel {
+    /// Stop receiving object change notifications through this channel.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn stop(&self) -> Result<(), crate::Error> {
+        self.stop_async().await
+    }
+
+    pub async fn stop_async(&self) -> Result<(), crate::Error> {
+        let url = format!("{}/channels/stop", crate::BASE_URL);
+        let response = reqwest::Client::new()
+            .post(&url)
+            .headers(crate::get_headers().await?)
+            .send().await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/common.rs
+++ b/vendor/cloud-storage-rs/src/resources/common.rs
@@ -1,0 +1,257 @@
+use serde::Serializer;
+use std::str::FromStr;
+
+/// Contains information about the team related to this `DefaultObjectAccessControls`
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectTeam {
+    /// The project number.
+    project_number: String,
+    /// The team.
+    team: Team,
+}
+
+/// Any type of team we can encounter.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Team {
+    /// The team consists of `Editors`.
+    Editors,
+    /// The team consists of `Owners`.
+    Owners,
+    /// The team consists of `Viewers`.
+    Viewers,
+}
+
+impl std::fmt::Display for Team {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Team::Editors => write!(f, "editors"),
+            Team::Owners => write!(f, "owners"),
+            Team::Viewers => write!(f, "viewers"),
+        }
+    }
+}
+
+impl FromStr for Team {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "editors" => Ok(Self::Editors),
+            "owners" => Ok(Self::Owners),
+            "viewers" => Ok(Self::Viewers),
+            _ => Err(format!("Invalid `Team`: {}", s)),
+        }
+    }
+}
+
+/// Any type of role we can encounter.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Role {
+    /// Full access.
+    Owner,
+    /// Write, but not administer.
+    Writer,
+    /// Only read access.
+    Reader,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ListResponse<T> {
+    #[serde(default = "Vec::new")]
+    pub items: Vec<T>,
+    pub next_page_token: Option<String>,
+}
+
+/// An entity is used to represent a user or group of users that often have some kind of permission.
+#[derive(Debug, PartialEq, Clone)]
+pub enum Entity {
+    /// A single user, identified by its id.
+    UserId(String),
+    /// A single user, identified by its email address.
+    UserEmail(String),
+    /// A group of users, identified by its id.
+    GroupId(String),
+    /// A group of users, identified by its email address.
+    GroupEmail(String),
+    /// All users identifed by an email that ends with the domain, for example `mydomain.rs` in
+    /// `me@mydomain.rs`.
+    Domain(String),
+    /// All users within a project, identified by the `team` name and `project` id.
+    Project(Team, String),
+    /// All users.
+    AllUsers,
+    /// All users that are logged in.
+    AllAuthenticatedUsers,
+}
+
+use Entity::*;
+
+impl std::fmt::Display for Entity {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            UserId(s) => write!(f, "user-{}", s),
+            UserEmail(s) => write!(f, "user-{}", s),
+            GroupId(s) => write!(f, "group-{}", s),
+            GroupEmail(s) => write!(f, "group-{}", s),
+            Domain(s) => write!(f, "domain-{}", s),
+            Project(team, project_id) => write!(f, "project-{}-{}", team, project_id),
+            AllUsers => write!(f, "allUsers"),
+            AllAuthenticatedUsers => write!(f, "allAuthenticatedUsers"),
+        }
+    }
+}
+
+impl serde::Serialize for Entity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}", self))
+    }
+}
+
+struct EntityVisitor;
+
+impl<'de> serde::de::Visitor<'de> for EntityVisitor {
+    type Value = Entity;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("an `Entity` resource")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let parts: Vec<&str> = value.split('-').collect();
+        let result = match &parts[..] {
+            ["user", rest @ ..] if is_email(rest) => UserEmail(rest.join("-")),
+            ["user", rest @ ..] => UserId(rest.join("-")),
+            ["group", rest @ ..] if is_email(rest) => GroupEmail(rest.join("-")),
+            ["group", rest @ ..] => GroupId(rest.join("-")),
+            ["domain", rest @ ..] => Domain(rest.join("-")),
+            ["project", team, project_id] => {
+                Project(Team::from_str(team).unwrap(), project_id.to_string())
+            }
+            ["allUsers"] => AllUsers,
+            ["allAuthenticatedUsers"] => AllAuthenticatedUsers,
+            _ => return Err(E::custom(format!("Unexpected `Entity`: {}", value))),
+        };
+        Ok(result)
+    }
+}
+
+fn is_email(pattern: &[&str]) -> bool {
+    pattern.iter().any(|s| s.contains('@'))
+}
+
+impl<'de> serde::Deserialize<'de> for Entity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(EntityVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize() {
+        let entity1 = UserId("some id".to_string());
+        assert_eq!(serde_json::to_string(&entity1).unwrap(), "\"user-some id\"");
+
+        let entity2 = UserEmail("some@email".to_string());
+        assert_eq!(
+            serde_json::to_string(&entity2).unwrap(),
+            "\"user-some@email\""
+        );
+
+        let entity3 = GroupId("some group id".to_string());
+        assert_eq!(
+            serde_json::to_string(&entity3).unwrap(),
+            "\"group-some group id\""
+        );
+
+        let entity4 = GroupEmail("some@group.email".to_string());
+        assert_eq!(
+            serde_json::to_string(&entity4).unwrap(),
+            "\"group-some@group.email\""
+        );
+
+        let entity5 = Domain("example.com".to_string());
+        assert_eq!(
+            serde_json::to_string(&entity5).unwrap(),
+            "\"domain-example.com\""
+        );
+
+        let entity6 = Project(Team::Viewers, "project id".to_string());
+        assert_eq!(
+            serde_json::to_string(&entity6).unwrap(),
+            "\"project-viewers-project id\""
+        );
+
+        let entity7 = AllUsers;
+        assert_eq!(serde_json::to_string(&entity7).unwrap(), "\"allUsers\"");
+
+        let entity8 = AllAuthenticatedUsers;
+        assert_eq!(
+            serde_json::to_string(&entity8).unwrap(),
+            "\"allAuthenticatedUsers\""
+        );
+    }
+
+    #[test]
+    fn deserialize() {
+        let str1 = "\"user-some id\"";
+        assert_eq!(
+            serde_json::from_str::<Entity>(str1).unwrap(),
+            UserId("some id".to_string())
+        );
+
+        let str2 = "\"user-some@email\"";
+        assert_eq!(
+            serde_json::from_str::<Entity>(str2).unwrap(),
+            UserEmail("some@email".to_string())
+        );
+
+        let str3 = "\"group-some group id\"";
+        assert_eq!(
+            serde_json::from_str::<Entity>(str3).unwrap(),
+            GroupId("some group id".to_string())
+        );
+
+        let str4 = "\"group-some@group.email\"";
+        assert_eq!(
+            serde_json::from_str::<Entity>(str4).unwrap(),
+            GroupEmail("some@group.email".to_string())
+        );
+
+        let str5 = "\"domain-example.com\"";
+        assert_eq!(
+            serde_json::from_str::<Entity>(str5).unwrap(),
+            Domain("example.com".to_string())
+        );
+
+        let str6 = "\"project-viewers-project id\"";
+        assert_eq!(
+            serde_json::from_str::<Entity>(str6).unwrap(),
+            Project(Team::Viewers, "project id".to_string())
+        );
+
+        let str7 = "\"allUsers\"";
+        assert_eq!(serde_json::from_str::<Entity>(str7).unwrap(), AllUsers);
+
+        let str8 = "\"allAuthenticatedUsers\"";
+        assert_eq!(
+            serde_json::from_str::<Entity>(str8).unwrap(),
+            AllAuthenticatedUsers
+        );
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/default_object_access_control.rs
+++ b/vendor/cloud-storage-rs/src/resources/default_object_access_control.rs
@@ -1,0 +1,446 @@
+#![allow(unused_imports)]
+
+use crate::error::GoogleResponse;
+use crate::resources::common::ListResponse;
+pub use crate::resources::common::{Entity, ProjectTeam, Role};
+
+/// The DefaultObjectAccessControls resources represent the Access Control Lists (ACLs) applied to a
+/// new object within Google Cloud Storage when no ACL was provided for that object. ACLs let you
+/// specify who has access to your data and to what extent.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DefaultObjectAccessControl {
+    /// The kind of item this is. For object access control entries, this is always
+    /// storage#objectAccessControl.
+    pub kind: String,
+    /// The entity holding the permission, in one of the following forms:
+    ///
+    /// * `user-userId`
+    /// * `user-email`
+    /// * `group-groupId`
+    /// * `group-email`
+    /// * `domain-domain`
+    /// * `project-team-projectId`
+    /// * `allUsers`
+    /// * `allAuthenticatedUsers`
+    ///
+    /// Examples:
+    ///
+    /// * The user liz@example.com would be user-liz@example.com.
+    /// * The group example@googlegroups.com would be group-example@googlegroups.com.
+    /// * To refer to all members of the G Suite for Business domain example.com, the entity would
+    /// be domain-example.com.
+    pub entity: Entity,
+    /// The access permission for the entity.
+    pub role: Role,
+    /// The email address associated with the entity, if any.
+    pub email: Option<String>,
+    /// The ID for the entity, if any.
+    pub entity_id: Option<String>,
+    /// The domain associated with the entity, if any.
+    pub domain: Option<String>,
+    /// The project team associated with the entity, if any.
+    pub project_team: Option<ProjectTeam>,
+    /// HTTP 1.1 Entity tag for the access-control entry.
+    pub etag: String,
+    /// The bucket this resource belongs to.
+    #[serde(default)]
+    pub bucket: String, // this field is not returned by Google, but we populate it manually for the
+                        // convenience of the end user.
+}
+
+/// Model that can be used to create a new DefaultObjectAccessControl object.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewDefaultObjectAccessControl {
+    /// The entity holding the permission, in one of the following forms:
+    ///
+    /// * `user-userId`
+    /// * `user-email`
+    /// * `group-groupId`
+    /// * `group-email`
+    /// * `domain-domain`
+    /// * `project-team-projectId`
+    /// * `allUsers`
+    /// * `allAuthenticatedUsers`
+    ///
+    /// Examples:
+    ///
+    /// * The user liz@example.com would be user-liz@example.com.
+    /// * The group example@googlegroups.com would be group-example@googlegroups.com.
+    /// * To refer to all members of the G Suite for Business domain example.com, the entity would
+    /// be domain-example.com.
+    pub entity: Entity,
+    /// The access permission for the entity.
+    pub role: Role,
+}
+
+impl DefaultObjectAccessControl {
+    /// Create a new `DefaultObjectAccessControl` entry on the specified bucket.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::default_object_access_control::{
+    ///     DefaultObjectAccessControl, NewDefaultObjectAccessControl, Role, Entity,
+    /// };
+    ///
+    /// let new_acl = NewDefaultObjectAccessControl {
+    ///     entity: Entity::AllAuthenticatedUsers,
+    ///     role: Role::Reader,
+    /// };
+    /// let default_acl = DefaultObjectAccessControl::create("mybucket", &new_acl).await?;
+    /// # default_acl.delete().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(
+        bucket: &str,
+        new_acl: &NewDefaultObjectAccessControl,
+    ) -> crate::Result<Self> {
+        let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .post(&url)
+            .headers(crate::get_headers().await?)
+            .json(new_acl)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(mut s) => {
+                s.bucket = bucket.to_string();
+                Ok(s)
+            }
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `DefautObjectAccessControl::create`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn create_sync(
+        bucket: &str,
+        new_acl: &NewDefaultObjectAccessControl,
+    ) -> crate::Result<Self> {
+        Self::create(bucket, new_acl).await
+    }
+
+    /// Retrieves default object ACL entries on the specified bucket.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::default_object_access_control::DefaultObjectAccessControl;
+    ///
+    /// let default_acls = DefaultObjectAccessControl::list("mybucket").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
+        let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
+        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s
+                .items
+                .into_iter()
+                .map(|item| DefaultObjectAccessControl {
+                    bucket: bucket.to_string(),
+                    ..item
+                })
+                .collect()),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `DefautObjectAccessControl::list`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn list_sync(bucket: &str) -> crate::Result<Vec<Self>> {
+        Self::list(bucket).await
+    }
+
+    /// Read a single `DefaultObjectAccessControl`.
+    /// The `bucket` argument is the name of the bucket whose `DefaultObjectAccessControl` is to be
+    /// read, and the `entity` argument is the entity holding the permission. Options are
+    /// Can be "user-`userId`", "user-`email_address`", "group-`group_id`", "group-`email_address`",
+    /// "allUsers", or "allAuthenticatedUsers".
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let default_acl = DefaultObjectAccessControl::read("mybucket", &Entity::AllUsers).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(bucket: &str, entity: &Entity) -> crate::Result<Self> {
+        let url = format!(
+            "{}/b/{}/defaultObjectAcl/{}",
+            crate::BASE_URL,
+            bucket,
+            entity
+        );
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(mut s) => {
+                s.bucket = bucket.to_string();
+                Ok(s)
+            }
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `DefautObjectAccessControl::read`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn read_sync(bucket: &str, entity: &Entity) -> crate::Result<Self> {
+        Self::read(bucket, entity).await
+    }
+
+    /// Update the current `DefaultObjectAccessControl`.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let mut default_acl = DefaultObjectAccessControl::read("my_bucket", &Entity::AllUsers).await?;
+    /// default_acl.entity = Entity::AllAuthenticatedUsers;
+    /// default_acl.update().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(&self) -> crate::Result<Self> {
+        let url = format!(
+            "{}/b/{}/defaultObjectAcl/{}",
+            crate::BASE_URL,
+            self.bucket,
+            self.entity
+        );
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .put(&url)
+            .headers(crate::get_headers().await?)
+            .json(self)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(mut s) => {
+                s.bucket = self.bucket.to_string();
+                Ok(s)
+            }
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `DefautObjectAccessControl::update`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn update_sync(&self) -> crate::Result<Self> {
+        self.update().await
+    }
+
+    /// Delete this 'DefaultObjectAccessControl`.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let mut default_acl = DefaultObjectAccessControl::read("my_bucket", &Entity::AllUsers).await?;
+    /// default_acl.delete().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(self) -> Result<(), crate::Error> {
+        let url = format!(
+            "{}/b/{}/defaultObjectAcl/{}",
+            crate::BASE_URL,
+            self.bucket,
+            self.entity
+        );
+        let response = reqwest::Client::new()
+            .delete(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+
+    /// The async equivalent of `DefautObjectAccessControl::delete`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn delete_sync(self) -> Result<(), crate::Error> {
+        self.delete().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn create() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let new_acl = NewDefaultObjectAccessControl {
+            entity: Entity::AllUsers,
+            role: Role::Reader,
+        };
+        DefaultObjectAccessControl::create(&bucket.name, &new_acl).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn read() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        NewDefaultObjectAccessControl {
+            entity: Entity::AllUsers,
+            role: Role::Reader,
+        };
+        DefaultObjectAccessControl::read(&bucket.name, &Entity::AllUsers).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        DefaultObjectAccessControl::list(&bucket.name).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let new_acl = NewDefaultObjectAccessControl {
+            entity: Entity::AllUsers,
+            role: Role::Reader,
+        };
+        let mut default_acl = DefaultObjectAccessControl::create(&bucket.name, &new_acl).await?;
+        default_acl.entity = Entity::AllAuthenticatedUsers;
+        default_acl.update().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let default_acl =
+            DefaultObjectAccessControl::read(&bucket.name, &Entity::AllAuthenticatedUsers).await?;
+        default_acl.delete().await?;
+        Ok(())
+    }
+
+    #[cfg(feature = "sync")]
+    mod sync {
+        use super::*;
+
+        #[test]
+        fn create() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let new_acl = NewDefaultObjectAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            DefaultObjectAccessControl::create_sync(&bucket.name, &new_acl)?;
+            Ok(())
+        }
+
+        #[test]
+        fn read() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let new_acl = NewDefaultObjectAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            DefaultObjectAccessControl::create_sync(&bucket.name, &new_acl)?;
+            DefaultObjectAccessControl::read_sync(&bucket.name, &Entity::AllUsers)?;
+            Ok(())
+        }
+
+        #[test]
+        fn list() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            DefaultObjectAccessControl::list_sync(&bucket.name)?;
+            Ok(())
+        }
+
+        #[test]
+        fn update() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let new_acl = NewDefaultObjectAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            let mut default_acl = DefaultObjectAccessControl::create_sync(&bucket.name, &new_acl)?;
+            default_acl.entity = Entity::AllAuthenticatedUsers;
+            default_acl.update_sync()?;
+            Ok(())
+        }
+
+        #[test]
+        fn delete() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let new_acl = NewDefaultObjectAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            let acl = DefaultObjectAccessControl::create_sync(&bucket.name, &new_acl)?;
+            acl.delete_sync()?;
+            Ok(())
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/default_object_access_control.rs
+++ b/vendor/cloud-storage-rs/src/resources/default_object_access_control.rs
@@ -347,10 +347,12 @@ mod tests {
     #[tokio::test]
     async fn read() -> Result<(), Box<dyn std::error::Error>> {
         let bucket = crate::read_test_bucket().await;
+        /*
         NewDefaultObjectAccessControl {
             entity: Entity::AllUsers,
             role: Role::Reader,
         };
+        */
         DefaultObjectAccessControl::read(&bucket.name, &Entity::AllUsers).await?;
         Ok(())
     }

--- a/vendor/cloud-storage-rs/src/resources/hmac_key.rs
+++ b/vendor/cloud-storage-rs/src/resources/hmac_key.rs
@@ -1,0 +1,451 @@
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
+use crate::error::GoogleResponse;
+
+/// The `HmacKey` resource represents an HMAC key within Cloud Storage. The resource consists of a
+/// secret and `HmacMeta`. HMAC keys can be used as credentials for service accounts. For more
+/// information, see HMAC Keys.
+///
+/// Note that the `HmacKey` resource is only returned when you use `HmacKey::create`. Other
+/// methods, such as `HmacKey::read`, return the metadata portion of the HMAC key resource.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HmacKey {
+    /// The kind of item this is. For HMAC keys, this is always `storage#hmacKey`.
+    pub kind: String,
+    /// HMAC key metadata.
+    pub metadata: HmacMeta,
+    /// HMAC secret key material.
+    pub secret: String,
+}
+
+/// Contains information about an Hmac Key.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HmacMeta {
+    /// The kind of item this is. For HMAC key metadata, this is always `storage#hmacKeyMetadata`.
+    pub kind: String,
+    /// The ID of the HMAC key, including the Project ID and the Access ID.
+    pub id: String,
+    /// The link to this resource.
+    pub self_link: String,
+    /// The access ID of the HMAC Key.
+    pub access_id: String,
+    /// The Project ID of the project that owns the service account to which the key authenticates.
+    pub project_id: String,
+    /// The email address of the key's associated service account.
+    pub service_account_email: String,
+    /// The state of the key.
+    pub state: HmacState,
+    /// The creation time of the HMAC key.
+    pub time_created: chrono::DateTime<chrono::Utc>,
+    /// The last modification time of the HMAC key metadata.
+    pub updated: chrono::DateTime<chrono::Utc>,
+    /// HTTP 1.1 Entity tag for the HMAC key.
+    pub etag: String,
+}
+
+/// The state of an Hmac Key.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HmacState {
+    /// This Hmac key is currently used.
+    Active,
+    /// This Hmac key has been set to inactive.
+    Inactive,
+    /// This Hmac key has been permanently deleted.
+    Deleted,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ListResponse {
+    items: Vec<HmacMeta>,
+}
+
+#[derive(serde::Serialize)]
+struct UpdateRequest {
+    secret: String,
+    metadata: UpdateMeta,
+}
+
+#[derive(serde::Serialize)]
+struct UpdateMeta {
+    state: HmacState,
+}
+
+impl HmacKey {
+    /// Creates a new HMAC key for the specified service account.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.create` permission for the project in
+    /// which the key will be created.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let hmac_key = HmacKey::create().await?;
+    /// # use cloud_storage::hmac_key::HmacState;
+    /// # HmacKey::update(&hmac_key.metadata.access_id, HmacState::Inactive).await?;
+    /// # HmacKey::delete(&hmac_key.metadata.access_id).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create() -> crate::Result<Self> {
+        use reqwest::header::CONTENT_LENGTH;
+
+        let url = format!(
+            "{}/projects/{}/hmacKeys",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id
+        );
+        let query = [("serviceAccountEmail", &crate::SERVICE_ACCOUNT.client_email)];
+        let mut headers = crate::get_headers().await?;
+        headers.insert(CONTENT_LENGTH, 0.into());
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .post(&url)
+            .headers(headers)
+            .query(&query)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `HmacKey::create`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn create_sync() -> crate::Result<Self> {
+        Self::create().await
+    }
+
+    /// Retrieves a list of HMAC keys matching the criteria. Since the HmacKey is secret, this does
+    /// not return a `HmacKey`, but a `HmacMeta`. This is a redacted version of a `HmacKey`, but
+    /// with the secret data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.list` permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let all_hmac_keys = HmacKey::list().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list() -> crate::Result<Vec<HmacMeta>> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id
+        );
+        let response = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .text()
+            .await?;
+        let result: Result<GoogleResponse<ListResponse>, _> = serde_json::from_str(&response);
+
+        // This function rquires more complicated error handling because when there is only one
+        // entry, Google will return the response `{ "kind": "storage#hmacKeysMetadata" }` instead
+        // of a list with one element. This breaks the parser.
+        match result {
+            Ok(parsed) => match parsed {
+                GoogleResponse::Success(s) => Ok(s.items),
+                GoogleResponse::Error(e) => Err(e.into()),
+            },
+            Err(_) => Ok(vec![]),
+        }
+    }
+
+    /// The async equivalent of `HmacKey::list`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn list_sync() -> crate::Result<Vec<HmacMeta>> {
+        Self::list().await
+    }
+
+    /// Retrieves an HMAC key's metadata. Since the HmacKey is secret, this does not return a
+    /// `HmacKey`, but a `HmacMeta`. This is a redacted version of a `HmacKey`, but with the secret
+    /// data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.get` permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let key = HmacKey::read("some identifier").await?;
+    /// # Ok(())
+    /// # }
+    pub async fn read(access_id: &str) -> crate::Result<HmacMeta> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys/{}",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id,
+            access_id
+        );
+        let result: GoogleResponse<HmacMeta> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `HmacKey::read`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn read_sync(access_id: &str) -> crate::Result<HmacMeta> {
+        Self::read(access_id).await
+    }
+
+    /// Updates the state of an HMAC key. See the HMAC Key resource descriptor for valid states.
+    /// Since the HmacKey is secret, this does not return a `HmacKey`, but a `HmacMeta`. This is a
+    /// redacted version of a `HmacKey`, but with the secret data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.update` permission for the project in
+    /// which the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::hmac_key::{HmacKey, HmacState};
+    ///
+    /// let key = HmacKey::update("your key", HmacState::Active).await?;
+    /// # Ok(())
+    /// # }
+    pub async fn update(access_id: &str, state: HmacState) -> crate::Result<HmacMeta> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys/{}",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id,
+            access_id
+        );
+        serde_json::to_string(&UpdateMeta { state })?;
+        let result: GoogleResponse<HmacMeta> = reqwest::Client::new()
+            .put(&url)
+            .headers(crate::get_headers().await?)
+            .json(&UpdateMeta { state })
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `HmacKey::update`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn update_sync(access_id: &str, state: HmacState) -> crate::Result<HmacMeta> {
+        Self::update(access_id, state).await
+    }
+
+    /// Deletes an HMAC key. Note that a key must be set to `Inactive` first.
+    ///
+    /// The authenticated user must have storage.hmacKeys.delete permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::hmac_key::{HmacKey, HmacState};
+    ///
+    /// let key = HmacKey::update("your key", HmacState::Inactive).await?; // this is required.
+    /// HmacKey::delete(&key.access_id).await?;
+    /// # Ok(())
+    /// # }
+    pub async fn delete(access_id: &str) -> crate::Result<()> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys/{}",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id,
+            access_id
+        );
+        let response = reqwest::Client::new()
+            .delete(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+
+    /// The synchronous equivalent of `HmacKey::delete`.
+    #[tokio::main]
+    #[cfg(feature = "sync")]
+    pub async fn delete_sync(access_id: &str) -> crate::Result<()> {
+        Self::delete(access_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn get_test_hmac() -> HmacMeta {
+        match HmacKey::create().await {
+            Ok(key) => key.metadata,
+            Err(_) => HmacKey::list().await.unwrap().pop().unwrap(),
+        }
+    }
+
+    async fn remove_test_hmac(access_id: &str) {
+        HmacKey::update(access_id, HmacState::Inactive)
+            .await
+            .unwrap();
+        HmacKey::delete(access_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn create() -> Result<(), Box<dyn std::error::Error>> {
+        let key = HmacKey::create().await?;
+        remove_test_hmac(&key.metadata.access_id).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list() -> Result<(), Box<dyn std::error::Error>> {
+        HmacKey::list().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn read() -> Result<(), Box<dyn std::error::Error>> {
+        let key = get_test_hmac().await;
+        HmacKey::read(&key.access_id).await?;
+        remove_test_hmac(&key.access_id).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update() -> Result<(), Box<dyn std::error::Error>> {
+        let key = get_test_hmac().await;
+        HmacKey::update(&key.access_id, HmacState::Inactive).await?;
+        HmacKey::delete(&key.access_id).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete() -> Result<(), Box<dyn std::error::Error>> {
+        let key = get_test_hmac().await;
+        HmacKey::update(&key.access_id, HmacState::Inactive).await?;
+        HmacKey::delete(&key.access_id).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn clear_keys() -> Result<(), Box<dyn std::error::Error>> {
+        let keys = HmacKey::list().await?;
+        for key in &keys {
+            if key.state != HmacState::Inactive {
+                HmacKey::update(&key.access_id, HmacState::Inactive).await?;
+            }
+            HmacKey::delete(&key.access_id).await?;
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "sync")]
+    mod sync {
+        use super::*;
+
+        fn get_test_hmac() -> HmacMeta {
+            match HmacKey::create_sync() {
+                Ok(key) => key.metadata,
+                Err(_) => HmacKey::list_sync().unwrap().pop().unwrap(),
+            }
+        }
+
+        fn remove_test_hmac(access_id: &str) {
+            HmacKey::update_sync(access_id, HmacState::Inactive).unwrap();
+            HmacKey::delete_sync(access_id).unwrap();
+        }
+
+        #[test]
+        fn create() -> Result<(), Box<dyn std::error::Error>> {
+            let key = HmacKey::create_sync()?;
+            remove_test_hmac(&key.metadata.access_id);
+            Ok(())
+        }
+
+        #[test]
+        fn list() -> Result<(), Box<dyn std::error::Error>> {
+            HmacKey::list_sync()?;
+            Ok(())
+        }
+
+        #[test]
+        fn read() -> Result<(), Box<dyn std::error::Error>> {
+            let key = get_test_hmac();
+            HmacKey::read_sync(&key.access_id)?;
+            remove_test_hmac(&key.access_id);
+            Ok(())
+        }
+
+        #[test]
+        fn update() -> Result<(), Box<dyn std::error::Error>> {
+            let key = get_test_hmac();
+            HmacKey::update_sync(&key.access_id, HmacState::Inactive)?;
+            HmacKey::delete_sync(&key.access_id)?;
+            Ok(())
+        }
+
+        #[test]
+        fn delete() -> Result<(), Box<dyn std::error::Error>> {
+            let key = get_test_hmac();
+            HmacKey::update_sync(&key.access_id, HmacState::Inactive)?;
+            HmacKey::delete_sync(&key.access_id)?;
+            Ok(())
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/location.rs
+++ b/vendor/cloud-storage-rs/src/resources/location.rs
@@ -1,0 +1,143 @@
+/// Deeply nested enum that represents a location where a bucket might store its files.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum Location {
+    /// Objects are stored in a single location.
+    Single(SingleRegion),
+    /// Objects are stored redundantly across multiple locations.
+    Multi(MultiRegion),
+    /// Objects are stored redundantly accross two locations.
+    Dual(DualRegion),
+}
+
+impl Default for Location {
+    fn default() -> Location {
+        Location::Single(SingleRegion::NorthAmerica(NALocation::SouthCarolina))
+    }
+}
+
+/// The possible options for single regions.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum SingleRegion {
+    /// All options in North America.
+    NorthAmerica(NALocation),
+    /// All options in South America.
+    SouthAmerica(SALocation),
+    /// All options in Europe.
+    Europe(EuropeLocation),
+    /// All options in Asia.
+    Asia(AsiaLocation),
+    /// All options in Australia.
+    Australia(AusLocation),
+}
+
+/// All options in North America.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum NALocation {
+    /// Store the files in Montréal.
+    #[serde(rename = "NORTHAMERICA-NORTHEAST1")]
+    Montreal,
+    /// Store the files in Iowa.
+    #[serde(rename = "US-CENTRAL1")]
+    Iowa,
+    /// Store the files in South Carolina.
+    #[serde(rename = "US-EAST1")]
+    SouthCarolina,
+    /// Store the files in Northern Virginia.
+    #[serde(rename = "US-EAST4")]
+    NorthernVirginia,
+    /// Store the files in Oregon.
+    #[serde(rename = "US-WEST1")]
+    Oregon,
+    /// Store the files in Los Angeles.
+    #[serde(rename = "US-WEST2")]
+    LosAngeles,
+}
+
+/// All options in South America.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum SALocation {
+    /// Store the files in Soa Paulo.
+    #[serde(rename = "SOUTHAMERICA-EAST1")]
+    SaoPaulo,
+}
+
+/// All options in Europe.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum EuropeLocation {
+    /// Store the files in Finland.
+    #[serde(rename = "EUROPE-NORTH1")]
+    Finland,
+    /// Store the files in Belgium.
+    #[serde(rename = "EUROPE-WEST1")]
+    Belgium,
+    /// Store the files in London.
+    #[serde(rename = "EUROPE-WEST2")]
+    London,
+    /// Store the files in Frankfurt.
+    #[serde(rename = "EUROPE-WEST3")]
+    Frankfurt,
+    /// Store the files in the Netherlands.
+    #[serde(rename = "EUROPE-WEST4")]
+    Netherlands,
+    /// Store the files in Zurich.
+    #[serde(rename = "EUROPE-WEST6")]
+    Zurich,
+}
+
+/// ALl options in Asia.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum AsiaLocation {
+    /// Store the files in Taiwan.
+    #[serde(rename = "ASIA-EAST1")]
+    Taiwan,
+    /// Store the files in Hong Kong.
+    #[serde(rename = "ASIA-EAST2")]
+    HongKong,
+    /// Store the files in Tokyo.
+    #[serde(rename = "ASIA-NORTHEAST1")]
+    Tokyo,
+    /// Store the files in Osaka.
+    #[serde(rename = "ASIA-NORTHEAST2")]
+    Osaka,
+    /// Store the files in Mumbai.
+    #[serde(rename = "ASIA-SOUTH1")]
+    Mumbai,
+    /// Store the files in Singapore.
+    #[serde(rename = "ASIA-SOUTHEAST1")]
+    Singapore,
+}
+
+/// All options in Australia.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum AusLocation {
+    /// Store the files in Sydney.
+    #[serde(rename = "AUSTRALIA-SOUTHEAST1")]
+    Sydney,
+}
+
+/// The possible options for multi-region storage.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum MultiRegion {
+    /// Data centers in Asia
+    Asia,
+    /// Data centers in the European Union
+    ///
+    /// Object data added to a bucket in the EU multi-region is not stored in the EUROPE-WEST2 or
+    /// EUROPE-WEST6 data center.
+    Eu,
+    /// Data centers in the United States
+    Us,
+}
+
+/// The possible options for dual-region storage
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum DualRegion {
+    /// EUROPE-NORTH1 and EUROPE-WEST4. Additionally, object metadata may be stored in EUROPE-WEST1.
+    Eur4,
+    /// US-CENTRAL1 and US-EAST1. Additionally, object metadata may be stored in Tulsa, Oklahoma.
+    Nam4,
+}

--- a/vendor/cloud-storage-rs/src/resources/mod.rs
+++ b/vendor/cloud-storage-rs/src/resources/mod.rs
@@ -1,0 +1,28 @@
+/// This complex object represents a Bucket that can be used to store and read files in Google Cloud
+/// Storage.
+pub mod bucket;
+/// A Bucket Access Control object can be used to configure access on a bucket-wide level.
+pub mod bucket_access_control;
+/// Commonly used types.
+pub mod common;
+/// Default Object Access Control objects can be used the configure access that is used as a
+/// fallback in the abscence of more specific data.
+pub mod default_object_access_control;
+/// An Hmac key is a secret key stored in Cloud Storage.
+pub mod hmac_key;
+/// A location where a bucket can exists physically.
+mod location;
+// /// A subscription to receive
+// /// [Pub/Sub notifications](https://cloud.google.com/storage/docs/pubsub-notifications).
+// pub mod notification;
+/// A file
+pub mod object;
+/// Contains data about to access specific files.
+pub mod object_access_control;
+/// A deserialized version of the `service-account-********.json` file. Used to authenticate
+/// requests.
+pub mod service_account;
+/// Used for parsing the `service-account-********.json` file.
+pub(crate) mod signature;
+/// The topic field of a `Notification`
+mod topic;

--- a/vendor/cloud-storage-rs/src/resources/notification.rs
+++ b/vendor/cloud-storage-rs/src/resources/notification.rs
@@ -1,0 +1,185 @@
+use crate::error::GoogleResponse;
+use crate::resources::common::ListResponse;
+pub use crate::resources::topic::Topic;
+
+/// A subscription to receive
+/// [Pub/Sub notifications](https://cloud.google.com/storage/docs/pubsub-notifications).
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Notification {
+    /// The ID of the notification.
+    id: String,
+    /// The Pub/Sub topic to which this subscription publishes. Formatted as:
+    /// `'//pubsub.googleapis.com/projects/{project-identifier}/topics/{my-topic}'`.
+    topic: Topic,
+    /// If present, only send notifications about listed event types. If empty, send notifications
+    /// for all event types.
+    event_types: Option<Vec<String>>,
+    /// An optional list of additional attributes to attach to each Pub/Sub message published
+    /// for this notification subscription.
+    custom_attributes: Option<std::collections::HashMap<String, String>>,
+    /// The desired content of the Payload.
+    ///
+    /// Acceptable values are:
+    /// * "JSON_API_V1"
+    /// * "NONE"
+    payload_format: String,
+    /// If present, only apply this notification configuration to object names that begin with this
+    /// prefix.
+    object_name_prefix: Option<String>,
+    /// HTTP 1.1 Entity tag for this subscription notification.
+    etag: String,
+    /// The canonical URL of this notification.
+    #[serde(rename = "selfLink")]
+    self_link: String,
+    /// The kind of item this is. For notifications, this is always `storage#notification`.   
+    kind: String,
+}
+
+/// Use this struct to create new notifications.
+#[derive(Debug, PartialEq, Default, serde::Serialize)]
+pub struct NewNotification {
+    /// The Pub/Sub topic to which this subscription publishes. Formatted as:
+    /// `'//pubsub.googleapis.com/projects/{project-identifier}/topics/{my-topic}'`.
+    topic: String,
+    /// If present, only send notifications about listed event types. If empty, send notifications
+    /// for all event types.
+    event_types: Option<Vec<String>>,
+    /// An optional list of additional attributes to attach to each Pub/Sub message published
+    /// for this notification subscription.
+    custom_attributes: Option<std::collections::HashMap<String, String>>,
+    /// The desired content of the Payload.
+    payload_format: Option<PayloadFormat>,
+    /// If present, only apply this notification configuration to object names that begin with this
+    /// prefix.
+    object_name_prefix: Option<String>,
+}
+
+/// Various ways of having the response formatted.
+#[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PayloadFormat {
+    /// Respond with a format as specified in the Json API V1 documentation.
+    JsonApiV1,
+    /// Do not respond.
+    None,
+}
+
+impl Notification {
+    /// Creates a notification subscription for a given bucket.
+    pub fn create(bucket: &str, new_notification: &NewNotification) -> Result<Self, crate::Error> {
+        let url = format!("{}/b/{}/notificationConfigs", crate::BASE_URL, bucket);
+        let client = reqwest::blocking::Client::new();
+        let result: GoogleResponse<Self> = client
+            .post(&url)
+            .headers(crate::get_headers()?)
+            .json(new_notification)
+            .send()?
+            .json()?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// View a notification configuration.
+    pub fn read(bucket: &str, notification: &str) -> Result<Self, crate::Error> {
+        let url = format!(
+            "{}/b/{}/notificationConfigs/{}",
+            crate::BASE_URL,
+            bucket,
+            notification
+        );
+        let client = reqwest::blocking::Client::new();
+        let result: GoogleResponse<Self> = client
+            .get(&url)
+            .headers(crate::get_headers()?)
+            .send()?
+            .json()?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Retrieves a list of notification subscriptions for a given bucket.}
+    pub fn list(bucket: &str) -> Result<Vec<Self>, crate::Error> {
+        let url = format!("{}/v1/b/{}/notificationConfigs", crate::BASE_URL, bucket);
+        let client = reqwest::blocking::Client::new();
+        let result: GoogleResponse<ListResponse<Self>> = client
+            .get(&url)
+            .headers(crate::get_headers()?)
+            .send()?
+            .json()?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.items),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Permanently deletes a notification subscription.
+    pub fn delete(bucket: &str, notification: &str) -> Result<(), crate::Error> {
+        let url = format!(
+            "{}/b/{}/notificationConfigs/{}",
+            crate::BASE_URL,
+            bucket,
+            notification
+        );
+        let client = reqwest::blocking::Client::new();
+        let response = client.get(&url).headers(crate::get_headers()?).send()?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json()?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create() {
+        let bucket = crate::read_test_bucket();
+        let topic = format!(
+            "//pubsub.googleapis.com/projects/{}/topics/{}",
+            crate::SERVICE_ACCOUNT.project_id,
+            "testing-is-important",
+        );
+        let new_notification = NewNotification {
+            topic,
+            payload_format: Some(PayloadFormat::JsonApiV1),
+            ..Default::default()
+        };
+        Notification::create(&bucket.name, &new_notification).unwrap();
+    }
+
+    #[test]
+    fn read() {
+        let bucket = crate::read_test_bucket();
+        Notification::read(&bucket.name, "testing-is-important").unwrap();
+    }
+
+    #[test]
+    fn list() {
+        let bucket = crate::read_test_bucket();
+        Notification::list(&bucket.name).unwrap();
+    }
+
+    #[test]
+    fn delete() {
+        let bucket = crate::read_test_bucket();
+        let topic = format!(
+            "//pubsub.googleapis.com/projects/{}/topics/{}",
+            crate::SERVICE_ACCOUNT.project_id,
+            "testing-is-important",
+        );
+        let new_notification = NewNotification {
+            topic,
+            payload_format: Some(PayloadFormat::JsonApiV1),
+            ..Default::default()
+        };
+        Notification::create(&bucket.name, &new_notification).unwrap();
+        Notification::delete(&bucket.name, "testing-is-important").unwrap();
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/object.rs
+++ b/vendor/cloud-storage-rs/src/resources/object.rs
@@ -1,0 +1,1537 @@
+use crate::error::{Error, GoogleResponse};
+pub use crate::resources::bucket::Owner;
+use crate::resources::common::ListResponse;
+use crate::resources::object_access_control::ObjectAccessControl;
+use futures::{stream, Stream, TryStream};
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+
+/// A resource representing a file in Google Cloud Storage.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Object {
+    /// The kind of item this is. For objects, this is always `storage#object`.
+    pub kind: String,
+    /// The ID of the object, including the bucket name, object name, and generation number.
+    pub id: String,
+    /// The link to this object.
+    pub self_link: String,
+    /// The name of the object. Required if not specified by URL parameter.
+    pub name: String,
+    /// The name of the bucket containing this object.
+    pub bucket: String,
+    /// The content generation of this object. Used for object versioning.
+    #[serde(deserialize_with = "crate::from_str")]
+    pub generation: i64,
+    /// The version of the metadata for this object at this generation. Used for preconditions and
+    /// for detecting changes in metadata. A metageneration number is only meaningful in the context
+    /// of a particular generation of a particular object.
+    #[serde(deserialize_with = "crate::from_str")]
+    pub metageneration: i64,
+    /// Content-Type of the object data. If an object is stored without a Content-Type, it is served
+    /// as application/octet-stream.
+    pub content_type: Option<String>,
+    /// The creation time of the object in RFC 3339 format.
+    pub time_created: chrono::DateTime<chrono::Utc>,
+    /// The modification time of the object metadata in RFC 3339 format.
+    pub updated: chrono::DateTime<chrono::Utc>,
+    /// The deletion time of the object in RFC 3339 format. Returned if and only if this version of
+    /// the object is no longer a live version, but remains in the bucket as a noncurrent version.
+    pub time_deleted: Option<chrono::DateTime<chrono::Utc>>,
+    /// Whether or not the object is subject to a temporary hold.
+    pub temporary_hold: Option<bool>,
+    /// Whether or not the object is subject to an event-based hold.
+    pub event_based_hold: Option<bool>,
+    /// The earliest time that the object can be deleted, based on a bucket's retention policy, in
+    /// RFC 3339 format.
+    pub retention_expiration_time: Option<chrono::DateTime<chrono::Utc>>,
+    /// Storage class of the object.
+    pub storage_class: String,
+    /// The time at which the object's storage class was last changed. When the object is initially
+    /// created, it will be set to timeCreated.
+    pub time_storage_class_updated: chrono::DateTime<chrono::Utc>,
+    /// Content-Length of the data in bytes.
+    #[serde(deserialize_with = "crate::from_str")]
+    pub size: u64,
+    /// MD5 hash of the data; encoded using base64. For more information about using the MD5 hash,
+    /// see Hashes and ETags: Best Practices.
+    pub md5_hash: Option<String>,
+    /// Media download link.
+    pub media_link: String,
+    /// Content-Encoding of the object data.
+    pub content_encoding: Option<String>,
+    /// Content-Disposition of the object data.
+    pub content_disposition: Option<String>,
+    /// Content-Language of the object data.
+    pub content_language: Option<String>,
+    /// Cache-Control directive for the object data. If omitted, and the object is accessible to all
+    /// anonymous users, the default will be public, max-age=3600.
+    pub cache_control: Option<String>,
+    /// User-provided metadata, in key/value pairs.
+    pub metadata: Option<std::collections::HashMap<String, String>>,
+    /// Access controls on the object, containing one or more objectAccessControls Resources. If
+    /// iamConfiguration.uniformBucketLevelAccess.enabled is set to true, this field is omitted in
+    /// responses, and requests that specify this field fail.
+    pub acl: Option<Vec<ObjectAccessControl>>,
+    /// The owner of the object. This will always be the uploader of the object. If
+    /// `iamConfiguration.uniformBucketLevelAccess.enabled` is set to true, this field does not
+    /// apply, and is omitted in responses.
+    pub owner: Option<Owner>,
+    /// CRC32c checksum, as described in RFC 4960, Appendix B; encoded using base64 in big-endian
+    /// byte order. For more information about using the CRC32c checksum, see Hashes and ETags: Best
+    /// Practices.
+    pub crc32c: String,
+    /// Number of underlying components that make up a composite object. Components are accumulated
+    /// by compose operations, counting 1 for each non-composite source object and componentCount
+    /// for each composite source object. Note: componentCount is included in the metadata for
+    /// composite objects only.
+    #[serde(default, deserialize_with = "crate::from_str_opt")]
+    pub component_count: Option<i32>,
+    /// HTTP 1.1 Entity tag for the object.
+    pub etag: String,
+    /// Metadata of customer-supplied encryption key, if the object is encrypted by such a key.
+    pub customer_encryption: Option<CustomerEncrypton>,
+    /// Cloud KMS Key used to encrypt this object, if the object is encrypted by such a key.
+    pub kms_key_name: Option<String>,
+}
+
+/// Contains data about how a user might encrypt their files in Google Cloud Storage.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomerEncrypton {
+    /// The encryption algorithm.
+    pub encryption_algorithm: String,
+    /// SHA256 hash value of the encryption key.
+    pub key_sha256: String,
+}
+
+/// The request that is supplied to perform `Object::compose`.
+#[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComposeRequest {
+    /// The kind of item this is. Will always be `storage#composeRequest`.
+    pub kind: String,
+    /// The list of source objects that will be concatenated into a single object.
+    pub source_objects: Vec<SourceObject>,
+    /// Properties of the resulting object.
+    pub destination: Option<Object>,
+}
+
+/// A SourceObject represents one of the objects that is to be composed.
+#[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceObject {
+    /// The source object's name. All source objects must have the same storage class and reside in
+    /// the same bucket.
+    pub name: String,
+    /// The generation of this object to use as the source.
+    pub generation: Option<i64>,
+    /// Conditions that must be met for this operation to execute.
+    pub object_preconditions: Option<ObjectPrecondition>,
+}
+
+/// Allows conditional copying of this file.
+#[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectPrecondition {
+    /// Only perform the composition if the generation of the source object that would be used
+    /// matches this value. If this value and a generation are both specified, they must be the same
+    /// value or the call will fail.
+    pub if_generation_match: i64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ObjectList {
+    kind: String,
+    items: Vec<Object>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RewriteResponse {
+    kind: String,
+    total_bytes_rewritten: String,
+    object_size: String,
+    done: bool,
+    resource: Object,
+}
+
+impl Object {
+    /// Create a new object with optional headers.
+    ///
+    /// You may wish to use [Preconditions](https://cloud.google.com/storage/docs/generations-preconditions)
+    /// when uploading data. This provides a option for a list of "mix-in" headers to apply
+    /// to create requests.
+    ///
+    /// ## Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn read_cute_cat(_in: &str) -> Vec<u8> { vec![0, 1] }
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let file: Vec<u8> = read_cute_cat("cat.png");
+    /// let client = Client::default();
+    /// let headers = reqwest::header::HeaderMap;
+    /// // Do not upload if cat.png is already present.
+    /// headers.append(
+    ///     "if-generation-match",
+    ///      reqwest::header::HeaderValue::from_str("0").unwrap());
+    ///
+    /// client.object().create_with_headers("cat-photos", file, "recently read cat.png", "image/png", Some(headers)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create_with_headers(
+        bucket: &str,
+        file: Vec<u8>,
+        filename: &str,
+        mime_type: &str,
+        additional_headers: Option<reqwest::header::HeaderMap>,
+    ) -> crate::Result<Self> {
+        use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
+
+        // has its own url for some reason
+        const BASE_URL: &str = "https://www.googleapis.com/upload/storage/v1/b";
+        let url = &format!(
+            "{}/{}/o?uploadType=media&name={}",
+            BASE_URL,
+            percent_encode(&bucket),
+            percent_encode(&filename),
+        );
+        let mut headers = crate::get_headers().await?;
+        if let Some(add_ins) = additional_headers {
+            for key in add_ins.keys() {
+                headers.insert(key, add_ins.get(key).unwrap().clone());
+            }
+        }
+        headers.insert(CONTENT_TYPE, mime_type.parse()?);
+        headers.insert(CONTENT_LENGTH, file.len().to_string().parse()?);
+        let response = reqwest::Client::new()
+            .post(url)
+            .headers(headers)
+            .body(file)
+            .send()
+            .await?;
+        if response.status() == 200 {
+            Ok(serde_json::from_str(&response.text().await?)?)
+        } else {
+            Err(Error::new(&response.text().await?))
+        }
+    }
+
+
+    /// Create a new object.
+    /// Upload a file as that is loaded in memory to google cloud storage, where it will be
+    /// interpreted according to the mime type you specified.
+    /// ## Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn read_cute_cat(_in: &str) -> Vec<u8> { vec![0, 1] }
+    /// use cloud_storage::Object;
+    ///
+    /// let file: Vec<u8> = read_cute_cat("cat.png");
+    /// Object::create("cat-photos", file, "recently read cat.png", "image/png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(
+        bucket: &str,
+        file: Vec<u8>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Self> {
+        Object::create_with_headers(bucket, file, filename, mime_type, None).await
+    }
+
+    /// The synchronous equivalent of `Object::create`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn create_sync(
+        bucket: &str,
+        file: Vec<u8>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Self> {
+        Self::create(bucket, file, filename, mime_type).await
+    }
+
+    /// Create a new object. This works in the same way as `Object::create`, except it does not need
+    /// to load the entire file in ram.
+    /// ## Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Object;
+    ///
+    /// let file = reqwest::Client::new()
+    ///     .get("https://my_domain.rs/nice_cat_photo.png")
+    ///     .send()
+    ///     .await?
+    ///     .bytes_stream();
+    /// Object::create_streamed("cat-photos", file, 10, "recently read cat.png", "image/png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create_streamed<S>(
+        bucket: &str,
+        stream: S,
+        length: impl Into<Option<u64>>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Self>
+    where
+        S: TryStream + Send + Sync + 'static,
+        S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        bytes::Bytes: From<S::Ok>,
+    {
+        use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
+
+        // has its own url for some reason
+        const BASE_URL: &str = "https://www.googleapis.com/upload/storage/v1/b";
+        let url = &format!(
+            "{}/{}/o?uploadType=media&name={}",
+            BASE_URL,
+            percent_encode(&bucket),
+            percent_encode(&filename),
+        );
+        let mut headers = crate::get_headers().await?;
+        headers.insert(CONTENT_TYPE, mime_type.parse()?);
+        if let Some(length) = length.into() {
+            headers.insert(CONTENT_LENGTH, length.into());
+        }
+
+        let body = reqwest::Body::wrap_stream(stream);
+        let response = reqwest::Client::new()
+            .post(url)
+            .headers(headers)
+            .body(body)
+            .send()
+            .await?;
+        if response.status() == 200 {
+            Ok(serde_json::from_str(&response.text().await?)?)
+        } else {
+            Err(Error::new(&response.text().await?))
+        }
+    }
+
+    /// The async equivalent of `Object::create_streamed`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn create_streamed_sync<R: std::io::Read + Send + 'static>(
+        bucket: &str,
+        mut file: R,
+        length: impl Into<Option<u64>>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Self> {
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer)
+            .map_err(|e| Error::Other(e.to_string()))?;
+
+        let stream = stream::once(async { Ok::<_, Error>(buffer) });
+
+        Self::create_streamed(bucket, stream, length, filename, mime_type).await
+    }
+
+    /// Obtain a list of objects within this Bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Object;
+    ///
+    /// let all_objects = Object::list("my_bucket").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(
+        bucket: &str,
+    ) -> Result<impl Stream<Item = Result<Vec<Self>, Error>> + '_, Error> {
+        Self::list_from(bucket, None).await
+    }
+
+    /// The async equivalent of `Object::list`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn list_sync(bucket: &str) -> Result<Vec<Self>, Error> {
+        use futures::TryStreamExt;
+
+        Self::list_from(bucket, None).await?.try_concat().await
+    }
+
+    /// Obtain a list of objects by prefix within this Bucket .
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Object;
+    ///
+    /// let all_objects = Object::list_prefix("my_bucket", "prefix/").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_prefix<'a>(
+        bucket: &'a str,
+        prefix: &'a str,
+    ) -> Result<impl Stream<Item = Result<Vec<Self>, Error>> + 'a, Error> {
+        Self::list_from(bucket, Some(prefix)).await
+    }
+
+    /// The async equivalent of `Object::list_prefix`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn list_prefix_sync(bucket: &str, prefix: &str) -> Result<Vec<Self>, Error> {
+        use futures::TryStreamExt;
+
+        Self::list_from(bucket, Some(prefix))
+            .await?
+            .try_concat()
+            .await
+    }
+
+    async fn list_from<'a>(
+        bucket: &'a str,
+        prefix: Option<&'a str>,
+    ) -> Result<impl Stream<Item = Result<Vec<Self>, Error>> + 'a, Error> {
+        #[derive(Clone)]
+        enum ListState {
+            Start,
+            HasMore(String),
+            Done,
+        }
+        use ListState::*;
+
+        Ok(stream::unfold(ListState::Start, move |state| async move {
+            let url = format!("{}/b/{}/o", crate::BASE_URL, percent_encode(bucket));
+            let headers = match crate::get_headers().await {
+                Ok(h) => h,
+                Err(e) => return Some((Err(e), state)),
+            };
+
+            let mut query = match state.clone() {
+                HasMore(page_token) => vec![("pageToken", page_token)],
+                Done => return None,
+                Start => vec![],
+            };
+
+            if let Some(prefix) = prefix {
+                query.push(("prefix", prefix.to_string()));
+            };
+
+            let response = reqwest::Client::new()
+                .get(&url)
+                .query(&query)
+                .headers(headers)
+                .send()
+                .await;
+            let response = match response {
+                Ok(r) => r,
+                Err(e) => return Some((Err(e.into()), state)),
+            };
+
+            let json = match response.json().await {
+                Ok(json) => json,
+                Err(e) => return Some((Err(e.into()), state)),
+            };
+
+            let result: GoogleResponse<ListResponse<Self>> = json;
+
+            let response_body = match result {
+                GoogleResponse::Success(success) => success,
+                GoogleResponse::Error(e) => return Some((Err(e.into()), state)),
+            };
+
+            let items = response_body.items;
+
+            let next_state = if let Some(page_token) = response_body.next_page_token {
+                HasMore(page_token)
+            } else {
+                Done
+            };
+
+            Some((Ok(items), next_state))
+        }))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Object;
+    ///
+    /// let object = Object::read("my_bucket", "path/to/my/file.png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(bucket: &str, file_name: &str) -> crate::Result<Self> {
+        let url = format!(
+            "{}/b/{}/o/{}",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Object::read`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn read_sync(bucket: &str, file_name: &str) -> crate::Result<Self> {
+        Self::read(bucket, file_name).await
+    }
+
+    /// Download the content of the object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Object;
+    ///
+    /// let bytes = Object::download("my_bucket", "path/to/my/file.png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn download(bucket: &str, file_name: &str) -> Result<Vec<u8>, Error> {
+        let url = format!(
+            "{}/b/{}/o/{}?alt=media",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        Ok(reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .bytes()
+            .await?
+            .to_vec())
+    }
+
+    /// The synchronous equivalent of `Object::download`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn download_sync(bucket: &str, file_name: &str) -> crate::Result<Vec<u8>> {
+        Self::download(bucket, file_name).await
+    }
+
+    /// Download the content of the object with the specified name in the specified bucket, without
+    /// allocating the whole file into a vector.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Object;
+    /// use futures::StreamExt;
+    /// use std::fs::File;
+    /// use std::io::Write;
+    ///
+    /// let mut stream = Object::download_streamed("my_bucket", "path/to/my/file.png").await?;
+    /// let mut file = File::create("file.png").unwrap();
+    /// for part in stream.next().await {
+    ///     file.write_all(&part.unwrap()).unwrap();
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn download_streamed(
+        bucket: &str,
+        file_name: &str,
+    ) -> crate::Result<impl Stream<Item = crate::Result<Vec<u8>>>> {
+        use futures::StreamExt;
+
+        let url = format!(
+            "{}/b/{}/o/{}?alt=media",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        Ok(reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .bytes_stream()
+            .map(|res| Ok(res.map(|r| r.to_vec())?)))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Object;
+    ///
+    /// let mut object = Object::read("my_bucket", "path/to/my/file.png").await?;
+    /// object.content_type = Some("application/xml".to_string());
+    /// object.update().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(&self) -> crate::Result<Self> {
+        let url = format!(
+            "{}/b/{}/o/{}",
+            crate::BASE_URL,
+            percent_encode(&self.bucket),
+            percent_encode(&self.name),
+        );
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .put(&url)
+            .headers(crate::get_headers().await?)
+            .json(&self)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Object::download`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn update_sync(&self) -> crate::Result<Self> {
+        self.update().await
+    }
+
+    /// Deletes a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Object;
+    ///
+    /// Object::delete("my_bucket", "path/to/my/file.png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(bucket: &str, file_name: &str) -> Result<(), Error> {
+        let url = format!(
+            "{}/b/{}/o/{}",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        let response = reqwest::Client::new()
+            .delete(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(Error::Google(response.json().await?))
+        }
+    }
+
+    /// The synchronous equivalent of `Object::delete`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn delete_sync(bucket: &str, file_name: &str) -> Result<(), Error> {
+        Self::delete(bucket, file_name).await
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::object::{Object, ComposeRequest, SourceObject};
+    ///
+    /// let obj1 = Object::read("my_bucket", "file1").await?;
+    /// let obj2 = Object::read("my_bucket", "file2").await?;
+    /// let compose_request = ComposeRequest {
+    ///     kind: "storage#composeRequest".to_string(),
+    ///     source_objects: vec![
+    ///         SourceObject {
+    ///             name: obj1.name.clone(),
+    ///             generation: None,
+    ///             object_preconditions: None,
+    ///         },
+    ///         SourceObject {
+    ///             name: obj2.name.clone(),
+    ///             generation: None,
+    ///             object_preconditions: None,
+    ///         },
+    ///     ],
+    ///     destination: None,
+    /// };
+    /// let obj3 = Object::compose("my_bucket", &compose_request, "test-concatted-file").await?;
+    /// // obj3 is now a file with the content of obj1 and obj2 concatted together.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn compose(
+        bucket: &str,
+        req: &ComposeRequest,
+        destination_object: &str,
+    ) -> crate::Result<Self> {
+        let url = format!(
+            "{}/b/{}/o/{}/compose",
+            crate::BASE_URL,
+            percent_encode(&bucket),
+            percent_encode(&destination_object)
+        );
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .post(&url)
+            .headers(crate::get_headers().await?)
+            .json(req)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Object::compose`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn compose_sync(
+        bucket: &str,
+        req: &ComposeRequest,
+        destination_object: &str,
+    ) -> crate::Result<Self> {
+        Self::compose(bucket, req, destination_object).await
+    }
+
+    /// Copy this object to the target bucket and path
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::object::{Object, ComposeRequest};
+    ///
+    /// let obj1 = Object::read("my_bucket", "file1").await?;
+    /// let obj2 = obj1.copy("my_other_bucket", "file2").await?;
+    /// // obj2 is now a copy of obj1.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn copy(&self, destination_bucket: &str, path: &str) -> crate::Result<Self> {
+        use reqwest::header::CONTENT_LENGTH;
+
+        let url = format!(
+            "{base}/b/{sBucket}/o/{sObject}/copyTo/b/{dBucket}/o/{dObject}",
+            base = crate::BASE_URL,
+            sBucket = percent_encode(&self.bucket),
+            sObject = percent_encode(&self.name),
+            dBucket = percent_encode(&destination_bucket),
+            dObject = percent_encode(&path),
+        );
+        let mut headers = crate::get_headers().await?;
+        headers.insert(CONTENT_LENGTH, "0".parse()?);
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .post(&url)
+            .headers(headers)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Object::copy`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn copy_sync(&self, destination_bucket: &str, path: &str) -> crate::Result<Self> {
+        self.copy(destination_bucket, path).await
+    }
+
+    /// Moves a file from the current location to the target bucket and path.
+    ///
+    /// ## Limitations
+    /// This function does not yet support rewriting objects to another
+    /// * Geographical Location,
+    /// * Encryption,
+    /// * Storage class.
+    /// These limitations mean that for now, the rewrite and the copy methods do the same thing.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::object::Object;
+    ///
+    /// let obj1 = Object::read("my_bucket", "file1").await?;
+    /// let obj2 = obj1.rewrite("my_other_bucket", "file2").await?;
+    /// // obj2 is now a copy of obj1.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn rewrite(&self, destination_bucket: &str, path: &str) -> crate::Result<Self> {
+        use reqwest::header::CONTENT_LENGTH;
+
+        let url = format!(
+            "{base}/b/{sBucket}/o/{sObject}/rewriteTo/b/{dBucket}/o/{dObject}",
+            base = crate::BASE_URL,
+            sBucket = percent_encode(&self.bucket),
+            sObject = percent_encode(&self.name),
+            dBucket = percent_encode(destination_bucket),
+            dObject = percent_encode(path),
+        );
+        let mut headers = crate::get_headers().await?;
+        headers.insert(CONTENT_LENGTH, "0".parse()?);
+        let result: GoogleResponse<RewriteResponse> = reqwest::Client::new()
+            .post(&url)
+            .headers(headers)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.resource),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The synchronous equivalent of `Object::rewrite`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn rewrite_sync(&self, destination_bucket: &str, path: &str) -> crate::Result<Self> {
+        self.rewrite(destination_bucket, path).await
+    }
+
+    /// Creates a [Signed Url](https://cloud.google.com/storage/docs/access-control/signed-urls)
+    /// which is valid for `duration` seconds, and lets the posessor download the file contents
+    /// without any authentication.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::object::{Object, ComposeRequest};
+    ///
+    /// let obj1 = Object::read("my_bucket", "file1").await?;
+    /// let url = obj1.download_url(50)?;
+    /// // url is now a url to which an unauthenticated user can make a request to download a file
+    /// // for 50 seconds.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn download_url(&self, duration: u32) -> crate::Result<String> {
+        self.sign(&self.name, duration, "GET", None)
+    }
+
+    /// Creates a [Signed Url](https://cloud.google.com/storage/docs/access-control/signed-urls)
+    /// which is valid for `duration` seconds, and lets the posessor download the file contents
+    /// without any authentication.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::object::{Object, ComposeRequest};
+    ///
+    /// let obj1 = Object::read("my_bucket", "file1").await?;
+    /// let url = obj1.download_url(50)?;
+    /// // url is now a url to which an unauthenticated user can make a request to download a file
+    /// // for 50 seconds.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn download_url_with(
+        &self,
+        duration: u32,
+        opts: crate::DownloadOptions,
+    ) -> crate::Result<String> {
+        self.sign(
+            &self.name,
+            duration,
+            "GET",
+            opts.content_disposition,
+        )
+    }
+
+    // /// Creates a [Signed Url](https://cloud.google.com/storage/docs/access-control/signed-urls)
+    // /// which is valid for `duration` seconds, and lets the posessor upload new file contents.
+    // /// without any authentication.
+    // pub fn upload_url(&self, duration: u32) -> crate::Result<String> {
+    //     self.sign(&self.name, duration, "POST")
+    // }
+
+    #[inline(always)]
+    fn sign(
+        &self,
+        file_path: &str,
+        duration: u32,
+        http_verb: &str,
+        content_disposition: Option<String>,
+    ) -> crate::Result<String> {
+        use openssl::sha;
+
+        if duration > 604800 {
+            let msg = format!(
+                "duration may not be greater than 604800, but was {}",
+                duration
+            );
+            return Err(Error::Other(msg));
+        }
+
+        // 0 Sort and construct the canonical headers
+        let mut headers = vec![];
+        headers.push(("host".to_string(), "storage.googleapis.com".to_string()));
+        headers.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(&k2));
+        let canonical_headers: String = headers
+            .iter()
+            .map(|(k, v)| format!("{}:{}", k.to_lowercase(), v.to_lowercase()))
+            .collect::<Vec<String>>()
+            .join("\n");
+        let signed_headers = headers
+            .iter()
+            .map(|(k, _)| k.to_lowercase())
+            .collect::<Vec<String>>()
+            .join(";");
+
+        // 1 construct the canonical request
+        let issue_date = chrono::Utc::now();
+        let file_path = self.path_to_resource(file_path);
+        let query_string = Self::get_canonical_query_string(
+            &issue_date,
+            duration,
+            &signed_headers,
+            content_disposition,
+        );
+        let canonical_request =
+            self.get_canonical_request(&file_path, &query_string, http_verb, &canonical_headers);
+
+        // 2 get hex encoded SHA256 hash the canonical request
+        let hash = sha::sha256(canonical_request.as_bytes());
+        let hex_hash = hex::encode(hash);
+
+        // 3 construct the string to sign
+        let string_to_sign = format!(
+            "{signing_algorithm}\n\
+            {current_datetime}\n\
+            {credential_scope}\n\
+            {hashed_canonical_request}",
+            signing_algorithm = "GOOG4-RSA-SHA256",
+            current_datetime = issue_date.format("%Y%m%dT%H%M%SZ"),
+            credential_scope = Self::get_credential_scope(&issue_date),
+            hashed_canonical_request = hex_hash,
+        );
+
+        // 4 sign the string to sign with RSA - SHA256
+        let buffer = Self::sign_str(&string_to_sign)?;
+        let signature = hex::encode(&buffer);
+
+        // 5 construct the signed url
+        Ok(format!(
+            "https://storage.googleapis.com{path_to_resource}?\
+            {query_string}&\
+            X-Goog-Signature={request_signature}",
+            path_to_resource = file_path,
+            query_string = query_string,
+            request_signature = signature,
+        ))
+    }
+
+    #[inline(always)]
+    fn get_canonical_request(
+        &self,
+        path: &str,
+        query_string: &str,
+        http_verb: &str,
+        headers: &str,
+    ) -> String {
+        format!(
+            "{http_verb}\n\
+            {path_to_resource}\n\
+            {canonical_query_string}\n\
+            {canonical_headers}\n\
+            \n\
+            {signed_headers}\n\
+            {payload}",
+            http_verb = http_verb,
+            path_to_resource = path,
+            canonical_query_string = query_string,
+            // canonical_headers = "host:storage.googleapis.com",
+            canonical_headers = headers,
+            signed_headers = "host",
+            payload = "UNSIGNED-PAYLOAD",
+        )
+    }
+
+    #[inline(always)]
+    fn get_canonical_query_string(
+        date: &chrono::DateTime<chrono::Utc>,
+        exp: u32,
+        headers: &str,
+        content_disposition: Option<String>,
+    ) -> String {
+        let credential = format!(
+            "{authorizer}/{scope}",
+            authorizer = crate::SERVICE_ACCOUNT.client_email,
+            scope = Self::get_credential_scope(date),
+        );
+        let mut s = format!(
+            "X-Goog-Algorithm={algo}&\
+            X-Goog-Credential={cred}&\
+            X-Goog-Date={date}&\
+            X-Goog-Expires={exp}&\
+            X-Goog-SignedHeaders={signed}",
+            algo = "GOOG4-RSA-SHA256",
+            cred = percent_encode(&credential),
+            date = date.format("%Y%m%dT%H%M%SZ"),
+            exp = exp,
+            // signed="host",
+            signed = headers,
+        );
+        if let Some(cd) = content_disposition {
+            s.push_str(&format!("&response-content-disposition={}", cd));
+        }
+        s
+    }
+
+    #[inline(always)]
+    fn path_to_resource(&self, path: &str) -> String {
+        format!(
+            "/{bucket}/{file_path}",
+            bucket = self.bucket,
+            file_path = percent_encode_noslash(path),
+        )
+    }
+
+    #[inline(always)]
+    fn get_credential_scope(date: &chrono::DateTime<chrono::Utc>) -> String {
+        format!("{}/henk/storage/goog4_request", date.format("%Y%m%d"))
+    }
+
+    #[inline(always)]
+    fn sign_str(message: &str) -> Result<Vec<u8>, Error> {
+        use openssl::{hash::MessageDigest, pkey::PKey, sign::Signer};
+
+        let key = PKey::private_key_from_pem(crate::SERVICE_ACCOUNT.private_key.as_bytes())?;
+        let mut signer = Signer::new(MessageDigest::sha256(), &key)?;
+        signer.update(message.as_bytes())?;
+        Ok(signer.sign_to_vec()?)
+    }
+}
+
+const ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'*')
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_');
+
+const NOSLASH_ENCODE_SET: &AsciiSet = &ENCODE_SET.remove(b'/').remove(b'~');
+
+// We need to be able to percent encode stuff, but without touching the slashes in filenames. To
+// this end we create an implementation that does this, without touching the slashes.
+fn percent_encode_noslash(input: &str) -> String {
+    utf8_percent_encode(input, NOSLASH_ENCODE_SET).to_string()
+}
+
+fn percent_encode(input: &str) -> String {
+    utf8_percent_encode(input, ENCODE_SET).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{StreamExt, TryStreamExt};
+
+    #[tokio::test]
+    async fn create() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        Object::create(&bucket.name, vec![0, 1], "test-create", "text/plain").await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_streamed() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let stream = stream::iter([0u8, 1].iter())
+            .map(Ok::<_, Box<dyn std::error::Error + Send + Sync>>)
+            .map_ok(|&b| bytes::BytesMut::from(&[b][..]));
+        Object::create_streamed(
+            &bucket.name,
+            stream,
+            2,
+            "test-create-streamed",
+            "text/plain",
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list() -> Result<(), Box<dyn std::error::Error>> {
+        let test_bucket = crate::read_test_bucket().await;
+        let _v: Vec<Object> = Object::list(&test_bucket.name).await?.try_concat().await?;
+        Ok(())
+    }
+
+    async fn flattened_list_prefix_stream(
+        bucket: &str,
+        prefix: &str,
+    ) -> Result<Vec<Object>, Box<dyn std::error::Error>> {
+        Ok(Object::list_prefix(bucket, prefix)
+            .await?
+            .try_concat()
+            .await?)
+    }
+
+    #[tokio::test]
+    async fn list_prefix() -> Result<(), Box<dyn std::error::Error>> {
+        let test_bucket = crate::read_test_bucket().await;
+
+        let prefix_names = [
+            "test-list-prefix/1",
+            "test-list-prefix/2",
+            "test-list-prefix/sub/1",
+            "test-list-prefix/sub/2",
+        ];
+
+        for name in &prefix_names {
+            Object::create(&test_bucket.name, vec![0, 1], name, "text/plain").await?;
+        }
+
+        let list = flattened_list_prefix_stream(&test_bucket.name, "test-list-prefix/").await?;
+        assert_eq!(list.len(), 4);
+        let list = flattened_list_prefix_stream(&test_bucket.name, "test-list-prefix/sub").await?;
+        assert_eq!(list.len(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn read() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        Object::create(&bucket.name, vec![0, 1], "test-read", "text/plain").await?;
+        Object::read(&bucket.name, "test-read").await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let content = b"hello world";
+        Object::create(
+            &bucket.name,
+            content.to_vec(),
+            "test-download",
+            "application/octet-stream",
+        )
+        .await?;
+
+        let data = Object::download(&bucket.name, "test-download").await?;
+        assert_eq!(data, content);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download_streamed() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let content = b"hello world";
+        Object::create(
+            &bucket.name,
+            content.to_vec(),
+            "test-download",
+            "application/octet-stream",
+        )
+        .await?;
+
+        let mut result = Object::download_streamed(&bucket.name, "test-download").await?;
+        let mut data = Vec::new();
+        for part in result.next().await {
+            data.extend(part?);
+        }
+        // let data = data.next().await.flat_map(|part| part.into_iter()).collect();
+        assert_eq!(data, content);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download_streamed_large() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let content = vec![5u8; 1_000_000];
+        Object::create(
+            &bucket.name,
+            content.to_vec(),
+            "test-download-large",
+            "application/octet-stream",
+        )
+        .await?;
+
+        let mut result = Object::download_streamed(&bucket.name, "test-download-large").await?;
+        let mut data: Vec<u8> = Vec::new();
+        while let Some(part) = result.next().await {
+            data.extend(part?);
+        }
+        assert_eq!(data, content);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let mut obj = Object::create(&bucket.name, vec![0, 1], "test-update", "text/plain").await?;
+        obj.content_type = Some("application/xml".to_string());
+        obj.update().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        Object::create(&bucket.name, vec![0, 1], "test-delete", "text/plain").await?;
+
+        Object::delete(&bucket.name, "test-delete").await?;
+
+        let list: Vec<_> = flattened_list_prefix_stream(&bucket.name, "test-delete").await?;
+        assert!(list.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+
+        let nonexistent_object = "test-delete-nonexistent";
+
+        let delete_result = Object::delete(&bucket.name, nonexistent_object).await;
+
+        if let Err(Error::Google(google_error_response)) = delete_result {
+            assert!(google_error_response.to_string().contains(&format!(
+                "No such object: {}/{}",
+                bucket.name, nonexistent_object
+            )));
+        } else {
+            panic!("Expected a Google error, instead got {:?}", delete_result);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn compose() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let obj1 = Object::create(&bucket.name, vec![0, 1], "test-compose-1", "text/plain").await?;
+        let obj2 = Object::create(&bucket.name, vec![2, 3], "test-compose-2", "text/plain").await?;
+        let compose_request = ComposeRequest {
+            kind: "storage#composeRequest".to_string(),
+            source_objects: vec![
+                SourceObject {
+                    name: obj1.name.clone(),
+                    generation: None,
+                    object_preconditions: None,
+                },
+                SourceObject {
+                    name: obj2.name.clone(),
+                    generation: None,
+                    object_preconditions: None,
+                },
+            ],
+            destination: None,
+        };
+        let obj3 = Object::compose(&bucket.name, &compose_request, "test-concatted-file").await?;
+        let url = obj3.download_url(100)?;
+        let content = reqwest::get(&url).await?.text().await?;
+        assert_eq!(content.as_bytes(), &[0, 1, 2, 3]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn copy() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let original = Object::create(&bucket.name, vec![2, 3], "test-copy", "text/plain").await?;
+        original.copy(&bucket.name, "test-copy - copy").await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rewrite() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let obj = Object::create(&bucket.name, vec![0, 1], "test-rewrite", "text/plain").await?;
+        let obj = obj.rewrite(&bucket.name, "test-rewritten").await?;
+        let url = obj.download_url(100)?;
+        let download = reqwest::Client::new().head(&url).send().await?;
+        assert_eq!(download.status().as_u16(), 200);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_url_encoding() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let complicated_names = [
+            "asdf",
+            "asdf+1",
+            "asdf&&+1?=3,,-_()*&^%$#@!`~{}[]\\|:;\"'<>,.?/äöüëß",
+            "https://www.google.com",
+            "परिक्षण फाईल",
+            "测试很重要",
+        ];
+        for name in &complicated_names {
+            let _obj = Object::create(&bucket.name, vec![0, 1], name, "text/plain").await?;
+            let obj = Object::read(&bucket.name, &name).await.unwrap();
+            let url = obj.download_url(100)?;
+            let download = reqwest::Client::new().head(&url).send().await?;
+            assert_eq!(download.status().as_u16(), 200);
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_download_url_with() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket().await;
+        let client = reqwest::Client::new();
+        let obj = Object::create(&bucket.name, vec![0, 1], "test-rewrite", "text/plain").await?;
+
+        let opts1 = crate::DownloadOptions::new().content_disposition("attachment");
+        let download_url1 = obj.download_url_with(100, opts1)?;
+        let download1 = client.head(&download_url1).send().await?;
+        assert_eq!(download1.headers()["content-disposition"], "attachment");
+        Ok(())
+    }
+
+    #[cfg(feature = "sync")]
+    mod sync {
+        use super::*;
+
+        #[test]
+        fn create() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            Object::create_sync(&bucket.name, vec![0, 1], "test-create", "text/plain")?;
+            Ok(())
+        }
+
+        #[test]
+        fn create_streamed() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let cursor = std::io::Cursor::new([0, 1]);
+            Object::create_streamed_sync(
+                &bucket.name,
+                cursor,
+                2,
+                "test-create-streamed",
+                "text/plain",
+            )?;
+            Ok(())
+        }
+
+        #[test]
+        fn list() -> Result<(), Box<dyn std::error::Error>> {
+            let test_bucket = crate::read_test_bucket_sync();
+            Object::list_sync(&test_bucket.name)?;
+            Ok(())
+        }
+
+        #[test]
+        fn list_prefix() -> Result<(), Box<dyn std::error::Error>> {
+            let test_bucket = crate::read_test_bucket_sync();
+
+            let prefix_names = [
+                "test-list-prefix/1",
+                "test-list-prefix/2",
+                "test-list-prefix/sub/1",
+                "test-list-prefix/sub/2",
+            ];
+
+            for name in &prefix_names {
+                Object::create_sync(&test_bucket.name, vec![0, 1], name, "text/plain")?;
+            }
+
+            let list = Object::list_prefix_sync(&test_bucket.name, "test-list-prefix/")?;
+            assert_eq!(list.len(), 4);
+            let list = Object::list_prefix_sync(&test_bucket.name, "test-list-prefix/sub")?;
+            assert_eq!(list.len(), 2);
+            Ok(())
+        }
+
+        #[test]
+        fn read() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            Object::create_sync(&bucket.name, vec![0, 1], "test-read", "text/plain")?;
+            Object::read_sync(&bucket.name, "test-read")?;
+            Ok(())
+        }
+
+        #[test]
+        fn download() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let content = b"hello world";
+            Object::create_sync(
+                &bucket.name,
+                content.to_vec(),
+                "test-download",
+                "application/octet-stream",
+            )?;
+
+            let data = Object::download_sync(&bucket.name, "test-download")?;
+            assert_eq!(data, content);
+
+            Ok(())
+        }
+
+        #[test]
+        fn update() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let mut obj =
+                Object::create_sync(&bucket.name, vec![0, 1], "test-update", "text/plain")?;
+            obj.content_type = Some("application/xml".to_string());
+            obj.update_sync()?;
+            Ok(())
+        }
+
+        #[test]
+        fn delete() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            Object::create_sync(&bucket.name, vec![0, 1], "test-delete", "text/plain")?;
+
+            Object::delete_sync(&bucket.name, "test-delete")?;
+
+            let list = Object::list_prefix_sync(&bucket.name, "test-delete")?;
+            assert!(list.is_empty());
+
+            Ok(())
+        }
+
+        #[test]
+        fn delete_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+
+            let nonexistent_object = "test-delete-nonexistent";
+
+            let delete_result = Object::delete_sync(&bucket.name, nonexistent_object);
+
+            if let Err(Error::Google(google_error_response)) = delete_result {
+                assert!(google_error_response.to_string().contains(&format!(
+                    "No such object: {}/{}",
+                    bucket.name, nonexistent_object
+                )));
+            } else {
+                panic!("Expected a Google error, instead got {:?}", delete_result);
+            }
+
+            Ok(())
+        }
+
+        #[test]
+        fn compose() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let obj1 =
+                Object::create_sync(&bucket.name, vec![0, 1], "test-compose-1", "text/plain")?;
+            let obj2 =
+                Object::create_sync(&bucket.name, vec![2, 3], "test-compose-2", "text/plain")?;
+            let compose_request = ComposeRequest {
+                kind: "storage#composeRequest".to_string(),
+                source_objects: vec![
+                    SourceObject {
+                        name: obj1.name.clone(),
+                        generation: None,
+                        object_preconditions: None,
+                    },
+                    SourceObject {
+                        name: obj2.name.clone(),
+                        generation: None,
+                        object_preconditions: None,
+                    },
+                ],
+                destination: None,
+            };
+            let obj3 = Object::compose_sync(&bucket.name, &compose_request, "test-concatted-file")?;
+            let url = obj3.download_url(100)?;
+            let content = reqwest::blocking::get(&url)?.text()?;
+            assert_eq!(content.as_bytes(), &[0, 1, 2, 3]);
+            Ok(())
+        }
+
+        #[test]
+        fn copy() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let original =
+                Object::create_sync(&bucket.name, vec![2, 3], "test-copy", "text/plain")?;
+            original.copy_sync(&bucket.name, "test-copy - copy")?;
+            Ok(())
+        }
+
+        #[test]
+        fn rewrite() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let obj = Object::create_sync(&bucket.name, vec![0, 1], "test-rewrite", "text/plain")?;
+            let obj = obj.rewrite_sync(&bucket.name, "test-rewritten")?;
+            let url = obj.download_url(100)?;
+            let client = reqwest::blocking::Client::new();
+            let download = client.head(&url).send()?;
+            assert_eq!(download.status().as_u16(), 200);
+            Ok(())
+        }
+
+        #[test]
+        fn test_url_encoding() -> Result<(), Box<dyn std::error::Error>> {
+            let bucket = crate::read_test_bucket_sync();
+            let complicated_names = [
+                "asdf",
+                "asdf+1",
+                "asdf&&+1?=3,,-_()*&^%$#@!`~{}[]\\|:;\"'<>,.?/äöüëß",
+                "https://www.google.com",
+                "परिक्षण फाईल",
+                "测试很重要",
+            ];
+            for name in &complicated_names {
+                let _obj = Object::create_sync(&bucket.name, vec![0, 1], name, "text/plain")?;
+                let obj = Object::read_sync(&bucket.name, &name).unwrap();
+                let url = obj.download_url(100)?;
+                let client = reqwest::blocking::Client::new();
+                let download = client.head(&url).send()?;
+                assert_eq!(download.status().as_u16(), 200);
+            }
+            Ok(())
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/object_access_control.rs
+++ b/vendor/cloud-storage-rs/src/resources/object_access_control.rs
@@ -1,0 +1,526 @@
+#![allow(unused_imports)]
+
+use crate::error::GoogleResponse;
+use crate::resources::common::ListResponse;
+pub use crate::resources::common::{Entity, ProjectTeam, Role};
+
+/// The ObjectAccessControls resources represent the Access Control Lists (ACLs) for objects within
+/// Google Cloud Storage. ACLs let you specify who has access to your data and to what extent.
+///
+/// ```text,ignore
+/// Important: The methods for this resource fail with a 400 Bad Request response for buckets with
+/// uniform bucket-level access enabled. Use storage.buckets.getIamPolicy and
+/// storage.buckets.setIamPolicy to control access instead.
+/// ```
+///
+/// There are two roles that can be assigned to an entity:
+///
+/// READERs can get an object, though the acl property will not be revealed.
+/// OWNERs are READERs, and they can get the acl property, update an object, and call all
+/// objectAccessControls methods on the object. The owner of an object is always an OWNER.
+///
+/// For more information, see Access Control, with the caveat that this API uses READER and OWNER
+/// instead of READ and FULL_CONTROL.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectAccessControl {
+    /// The kind of item this is. For object access control entries, this is always
+    /// `storage#objectAccessControl`.
+    pub kind: String,
+    /// The ID of the access-control entry.
+    pub id: String,
+    /// The link to this access-control entry.
+    pub self_link: String,
+    /// The name of the bucket.
+    pub bucket: String,
+    /// The name of the object, if applied to an object.
+    pub object: String,
+    /// The content generation of the object, if applied to an object.
+    pub generation: Option<String>,
+    /// The entity holding the permission, in one of the following forms:
+    ///
+    /// user-userId
+    /// user-email
+    /// group-groupId
+    /// group-email
+    /// domain-domain
+    /// project-team-projectId
+    /// allUsers
+    /// allAuthenticatedUsers
+    ///
+    /// Examples:
+    ///
+    /// The user liz@example.com would be user-liz@example.com.
+    /// The group example@googlegroups.com would be group-example@googlegroups.com.
+    /// To refer to all members of the G Suite for Business domain example.com, the entity would be
+    /// domain-example.com.
+    pub entity: Entity,
+    /// The access permission for the entity.
+    pub role: Role,
+    /// The email address associated with the entity, if any.
+    pub email: Option<String>,
+    /// The ID for the entity, if any.
+    pub entity_id: Option<String>,
+    /// The domain associated with the entity, if any.
+    pub domain: Option<String>,
+    /// The project team associated with the entity, if any.
+    pub project_team: Option<ProjectTeam>,
+    /// HTTP 1.1 Entity tag for the access-control entry.
+    pub etag: String,
+}
+
+/// Used to create a new `ObjectAccessControl` object.
+#[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewObjectAccessControl {
+    /// The entity holding the permission, in one of the following forms:
+    ///
+    /// user-userId
+    /// user-email
+    /// group-groupId
+    /// group-email
+    /// domain-domain
+    /// project-team-projectId
+    /// allUsers
+    /// allAuthenticatedUsers
+    ///
+    /// Examples:
+    ///
+    /// The user liz@example.com would be user-liz@example.com.
+    /// The group example@googlegroups.com would be group-example@googlegroups.com.
+    /// To refer to all members of the G Suite for Business domain example.com, the entity would be
+    /// domain-example.com.
+    pub entity: Entity,
+    /// The access permission for the entity.
+    pub role: Role,
+}
+
+#[allow(unused)]
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ObjectAccessControlList {
+    kind: String,
+    items: Vec<ObjectAccessControl>,
+}
+
+impl ObjectAccessControl {
+    /// Creates a new ACL entry on the specified `object`.
+    ///
+    /// ### Important
+    /// This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn create(
+        bucket: &str,
+        object: &str,
+        new_object_access_control: &NewObjectAccessControl,
+    ) -> crate::Result<Self> {
+        let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .post(&url)
+            .headers(crate::get_headers().await?)
+            .json(new_object_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The sync equivalent of `ObjectAccessControl::create`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn create_sync(
+        bucket: &str,
+        object: &str,
+        new_object_access_control: &NewObjectAccessControl,
+    ) -> crate::Result<Self> {
+        Self::create(bucket, object, new_object_access_control).await
+    }
+
+    /// Retrieves `ACL` entries on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn list(bucket: &str, object: &str) -> crate::Result<Vec<Self>> {
+        let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
+        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.items),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The sync equivalent of `ObjectAccessControl::list`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn list_sync(bucket: &str, object: &str) -> crate::Result<Vec<Self>> {
+        Self::list(bucket, object).await
+    }
+
+    /// Returns the `ACL` entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn read(bucket: &str, object: &str, entity: &Entity) -> crate::Result<Self> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl/{}",
+            crate::BASE_URL,
+            bucket,
+            object,
+            entity
+        );
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .get(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The sync equivalent of `ObjectAccessControl::read`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn read_sync(bucket: &str, object: &str, entity: &Entity) -> crate::Result<Self> {
+        Self::read(bucket, object, entity).await
+    }
+
+    /// Updates an ACL entry on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn update(&self) -> crate::Result<Self> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl/{}",
+            crate::BASE_URL,
+            self.bucket,
+            self.object,
+            self.entity,
+        );
+        let result: GoogleResponse<Self> = reqwest::Client::new()
+            .put(&url)
+            .headers(crate::get_headers().await?)
+            .json(self)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// The sync equivalent of `ObjectAccessControl::update`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn update_sync(&self) -> crate::Result<Self> {
+        self.update().await
+    }
+
+    /// Permanently deletes the ACL entry for the specified entity on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn delete(self) -> crate::Result<()> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl/{}",
+            crate::BASE_URL,
+            self.bucket,
+            self.object,
+            self.entity,
+        );
+        let response = reqwest::Client::new()
+            .delete(&url)
+            .headers(crate::get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+
+    /// The sync equivalent of `ObjectAccessControl::delete`.
+    ///
+    /// ### Features
+    /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
+    #[cfg(feature = "sync")]
+    #[tokio::main]
+    pub async fn delete_sync(self) -> crate::Result<()> {
+        self.delete().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Object;
+
+    #[tokio::test]
+    async fn create() {
+        let bucket = crate::read_test_bucket().await;
+        Object::create(
+            &bucket.name,
+            vec![0, 1],
+            "test-object-access-controls-create",
+            "text/plain",
+        )
+        .await
+        .unwrap();
+        let new_bucket_access_control = NewObjectAccessControl {
+            entity: Entity::AllUsers,
+            role: Role::Reader,
+        };
+        ObjectAccessControl::create(
+            &bucket.name,
+            "test-object-access-controls-create",
+            &new_bucket_access_control,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn list() {
+        let bucket = crate::read_test_bucket().await;
+        Object::create(
+            &bucket.name,
+            vec![0, 1],
+            "test-object-access-controls-list",
+            "text/plain",
+        )
+        .await
+        .unwrap();
+        ObjectAccessControl::list(&bucket.name, "test-object-access-controls-list")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn read() {
+        let bucket = crate::read_test_bucket().await;
+        Object::create(
+            &bucket.name,
+            vec![0, 1],
+            "test-object-access-controls-read",
+            "text/plain",
+        )
+        .await
+        .unwrap();
+        let new_bucket_access_control = NewObjectAccessControl {
+            entity: Entity::AllUsers,
+            role: Role::Reader,
+        };
+        ObjectAccessControl::create(
+            &bucket.name,
+            "test-object-access-controls-read",
+            &new_bucket_access_control,
+        )
+        .await
+        .unwrap();
+        ObjectAccessControl::read(
+            &bucket.name,
+            "test-object-access-controls-read",
+            &Entity::AllUsers,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn update() {
+        // use a seperate bucket to prevent synchronization issues
+        let bucket = crate::create_test_bucket("test-object-access-controls-update").await;
+        let new_bucket_access_control = NewObjectAccessControl {
+            entity: Entity::AllUsers,
+            role: Role::Reader,
+        };
+        Object::create(&bucket.name, vec![0, 1], "test-update", "text/plain")
+            .await
+            .unwrap();
+        ObjectAccessControl::create(&bucket.name, "test-update", &new_bucket_access_control)
+            .await
+            .unwrap();
+        let mut acl = ObjectAccessControl::read(&bucket.name, "test-update", &Entity::AllUsers)
+            .await
+            .unwrap();
+        acl.entity = Entity::AllAuthenticatedUsers;
+        acl.update().await.unwrap();
+        Object::delete(&bucket.name, "test-update").await.unwrap();
+        bucket.delete().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete() {
+        // use a seperate bucket to prevent synchronization issues
+        let bucket = crate::create_test_bucket("test-object-access-controls-delete").await;
+        let new_bucket_access_control = NewObjectAccessControl {
+            entity: Entity::AllUsers,
+            role: Role::Reader,
+        };
+        Object::create(&bucket.name, vec![0, 1], "test-delete", "text/plain")
+            .await
+            .unwrap();
+        ObjectAccessControl::create(&bucket.name, "test-delete", &new_bucket_access_control)
+            .await
+            .unwrap();
+        let acl = ObjectAccessControl::read(&bucket.name, "test-delete", &Entity::AllUsers)
+            .await
+            .unwrap();
+        acl.delete().await.unwrap();
+        Object::delete(&bucket.name, "test-delete").await.unwrap();
+        bucket.delete().await.unwrap();
+    }
+
+    #[cfg(feature = "sync")]
+    mod sync {
+        use super::*;
+
+        #[test]
+        fn create() {
+            let bucket = crate::read_test_bucket_sync();
+            Object::create_sync(
+                &bucket.name,
+                vec![0, 1],
+                "test-object-access-controls-create",
+                "text/plain",
+            )
+            .unwrap();
+            let new_bucket_access_control = NewObjectAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            ObjectAccessControl::create_sync(
+                &bucket.name,
+                "test-object-access-controls-create",
+                &new_bucket_access_control,
+            )
+            .unwrap();
+        }
+
+        #[test]
+        fn list() {
+            let bucket = crate::read_test_bucket_sync();
+            Object::create_sync(
+                &bucket.name,
+                vec![0, 1],
+                "test-object-access-controls-list",
+                "text/plain",
+            )
+            .unwrap();
+            ObjectAccessControl::list_sync(&bucket.name, "test-object-access-controls-list")
+                .unwrap();
+        }
+
+        #[test]
+        fn read() {
+            let bucket = crate::read_test_bucket_sync();
+            Object::create_sync(
+                &bucket.name,
+                vec![0, 1],
+                "test-object-access-controls-read",
+                "text/plain",
+            )
+            .unwrap();
+            let new_bucket_access_control = NewObjectAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            ObjectAccessControl::create_sync(
+                &bucket.name,
+                "test-object-access-controls-read",
+                &new_bucket_access_control,
+            )
+            .unwrap();
+            ObjectAccessControl::read_sync(
+                &bucket.name,
+                "test-object-access-controls-read",
+                &Entity::AllUsers,
+            )
+            .unwrap();
+        }
+
+        #[test]
+        fn update() {
+            // use a seperate bucket to prevent synchronization issues
+            let bucket = crate::create_test_bucket_sync("test-object-access-controls-update");
+            let new_bucket_access_control = NewObjectAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            Object::create_sync(&bucket.name, vec![0, 1], "test-update", "text/plain").unwrap();
+            ObjectAccessControl::create_sync(
+                &bucket.name,
+                "test-update",
+                &new_bucket_access_control,
+            )
+            .unwrap();
+            let mut acl =
+                ObjectAccessControl::read_sync(&bucket.name, "test-update", &Entity::AllUsers)
+                    .unwrap();
+            acl.entity = Entity::AllAuthenticatedUsers;
+            acl.update_sync().unwrap();
+            Object::delete_sync(&bucket.name, "test-update").unwrap();
+            bucket.delete_sync().unwrap();
+        }
+
+        #[test]
+        fn delete() {
+            // use a seperate bucket to prevent synchronization issues
+            let bucket = crate::create_test_bucket_sync("test-object-access-controls-delete");
+            let new_bucket_access_control = NewObjectAccessControl {
+                entity: Entity::AllUsers,
+                role: Role::Reader,
+            };
+            Object::create_sync(&bucket.name, vec![0, 1], "test-delete", "text/plain").unwrap();
+            ObjectAccessControl::create_sync(
+                &bucket.name,
+                "test-delete",
+                &new_bucket_access_control,
+            )
+            .unwrap();
+            let acl =
+                ObjectAccessControl::read_sync(&bucket.name, "test-delete", &Entity::AllUsers)
+                    .unwrap();
+            acl.delete_sync().unwrap();
+            Object::delete_sync(&bucket.name, "test-delete").unwrap();
+            bucket.delete_sync().unwrap();
+        }
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/service_account.rs
+++ b/vendor/cloud-storage-rs/src/resources/service_account.rs
@@ -1,0 +1,42 @@
+/// A deserialized `service-account-********.json`-file.
+#[derive(serde::Deserialize, Debug)]
+pub struct ServiceAccount {
+    /// The type of authentication, this should always be `service_account`.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    /// The name of the current project.
+    pub project_id: String,
+    /// A unqiue identifier for the private key.
+    pub private_key_id: String,
+    /// The private key in RSA format.
+    pub private_key: String,
+    /// The email address associated with the service account.
+    pub client_email: String,
+    /// The unique identifier for this client.
+    pub client_id: String,
+    /// The endpoint where authentication happens.
+    pub auth_uri: String,
+    /// The endpoint where OAuth2 tokens are issued.
+    pub token_uri: String,
+    /// The url of the cert provider.
+    pub auth_provider_x509_cert_url: String,
+    /// The url of a static file containing metadata for this certificate.
+    pub client_x509_cert_url: String,
+}
+
+impl ServiceAccount {
+    pub(crate) fn get() -> Self {
+        dotenv::dotenv().ok();
+        let path = std::env::var("SERVICE_ACCOUNT")
+            .or_else(|_| std::env::var("GOOGLE_APPLICATION_CREDENTIALS"))
+            .expect(
+                "SERVICE_ACCOUNT or GOOGLE_APPLICATION_CREDENTIALS environment parameter required",
+            );
+        let file = std::fs::read_to_string(path).expect("SERVICE_ACCOUNT file not found");
+        let account: Self = serde_json::from_str(&file).expect("serivce account file not valid");
+        if account.r#type != "service_account" {
+            panic!("`type` paramter of `SERVICE_ACCOUNT` variable is not 'service_account'");
+        }
+        account
+    }
+}

--- a/vendor/cloud-storage-rs/src/resources/signature.rs
+++ b/vendor/cloud-storage-rs/src/resources/signature.rs
@@ -1,0 +1,39 @@
+#[derive(serde::Deserialize, Debug)]
+#[serde(untagged)]
+pub enum SignatureResponse {
+    Success(SuccessResponse),
+    Failure(FailureResponse),
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SuccessResponse {
+    pub key_id: String,
+    pub signature: String,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct FailureResponse {
+    pub error: SignatureError,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct SignatureError {
+    pub code: u16,
+    pub message: String,
+    pub status: String,
+    pub details: Option<Vec<Details>>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct Details {
+    #[serde(rename = "@type")]
+    pub _type: String,
+    pub links: Vec<Link>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct Link {
+    pub description: String,
+    pub url: String,
+}

--- a/vendor/cloud-storage-rs/src/resources/topic.rs
+++ b/vendor/cloud-storage-rs/src/resources/topic.rs
@@ -1,0 +1,68 @@
+/// The topic of a notification
+#[derive(Debug, PartialEq)]
+pub struct Topic {
+    /// The project within which you want to receive notifications
+    pub project_id: String,
+    /// The topic of those notifications.
+    pub topic: String,
+}
+
+impl std::fmt::Display for Topic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "//pubsub.googleapis.com/projects/{}/topics/{}",
+            self.project_id, self.topic
+        )
+    }
+}
+
+impl serde::Serialize for Topic {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("{}", self))
+    }
+}
+
+struct TopicVisitor;
+
+impl<'de> serde::de::Visitor<'de> for TopicVisitor {
+    type Value = Topic;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("an `Topic` resource")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let mut parts_iter = value.split('/');
+        let error = || E::custom(format!("Invalid topic: `{}`", value));
+        const START: [&str; 4] = ["", "", "pubsub.googleapis.com", "projects"];
+        if parts_iter.clone().take(4).collect::<Vec<_>>() != START {
+            return Err(error());
+        }
+        let project_id = parts_iter.next().ok_or_else(error)?;
+        if parts_iter.next() != Some("topics") {
+            return Err(error());
+        }
+        let topic = parts_iter.next().ok_or_else(error)?;
+        let result = Topic {
+            project_id: project_id.to_string(),
+            topic: topic.to_string(),
+        };
+        Ok(result)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Topic {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(TopicVisitor)
+    }
+}

--- a/vendor/cloud-storage-rs/src/sync.rs
+++ b/vendor/cloud-storage-rs/src/sync.rs
@@ -1,0 +1,62 @@
+//! Synchronous clients for Google Cloud Storage endpoints.
+
+mod bucket;
+mod bucket_access_control;
+mod default_object_access_control;
+mod hmac_key;
+mod object;
+mod object_access_control;
+
+pub use bucket::BucketClient;
+pub use bucket_access_control::BucketAccessControlClient;
+pub use default_object_access_control::DefaultObjectAccessControlClient;
+pub use hmac_key::HmacKeyClient;
+pub use object::ObjectClient;
+pub use object_access_control::ObjectAccessControlClient;
+
+/// The primary synchronous entrypoint to perform operations with Google Cloud Storage.
+#[derive(Debug)]
+pub struct Client {
+    runtime: tokio::runtime::Runtime,
+    client: crate::client::Client,
+}
+
+impl Client {
+    /// Constructs a synchronous client
+    pub fn new() -> crate::Result<Self> {
+        Ok(Self {
+            runtime: crate::runtime()?,
+            client: Default::default(),
+        })
+    }
+
+    /// Synchronous operations on [`Bucket`](crate::bucket::Bucket)s.
+    pub fn bucket(&self) -> BucketClient<'_> {
+        BucketClient(self)
+    }
+
+    /// Synchronous operations on [`BucketAccessControl`](crate::bucket_access_control::BucketAccessControl)s.
+    pub fn bucket_access_control(&self) -> BucketAccessControlClient<'_> {
+        BucketAccessControlClient(self)
+    }
+
+    /// Synchronous operations on [`DefaultObjectAccessControl`](crate::default_object_access_control::DefaultObjectAccessControl)s.
+    pub fn default_object_access_control(&self) -> DefaultObjectAccessControlClient<'_> {
+        DefaultObjectAccessControlClient(self)
+    }
+
+    /// Synchronous operations on [`HmacKey`](crate::hmac_key::HmacKey)s.
+    pub fn hmac_key(&self) -> HmacKeyClient<'_> {
+        HmacKeyClient(self)
+    }
+
+    /// Synchronous operations on [`Object`](crate::object::Object)s.
+    pub fn object(&self) -> ObjectClient<'_> {
+        ObjectClient(self)
+    }
+
+    /// Synchronous operations on [`ObjectAccessControl`](crate::object_access_control::ObjectAccessControl)s.
+    pub fn object_access_control(&self) -> ObjectAccessControlClient<'_> {
+        ObjectAccessControlClient(self)
+    }
+}

--- a/vendor/cloud-storage-rs/src/sync/bucket.rs
+++ b/vendor/cloud-storage-rs/src/sync/bucket.rs
@@ -1,0 +1,235 @@
+use crate::{
+    bucket::{IamPolicy, TestIamPermission},
+    Bucket, NewBucket,
+};
+
+/// Operations on [`Bucket`]()s.
+#[derive(Debug)]
+pub struct BucketClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> BucketClient<'a> {
+    /// Creates a new `Bucket`. There are many options that you can provide for creating a new
+    /// bucket, so the `NewBucket` resource contains all of them. Note that `NewBucket` implements
+    /// `Default`, so you don't have to specify the fields you're not using. And error is returned
+    /// if that bucket name is already taken.
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket::{Bucket, NewBucket};
+    /// use cloud_storage::bucket::{Location, MultiRegion};
+    ///
+    /// let client = Client::new()?;
+    /// let new_bucket = NewBucket {
+    ///    name: "cloud-storage-rs-doc-1".to_string(), // this is the only mandatory field
+    ///    location: Location::Multi(MultiRegion::Eu),
+    ///    ..Default::default()
+    /// };
+    /// let bucket = client.bucket().create(&new_bucket)?;
+    /// # client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create(&self, new_bucket: &NewBucket) -> crate::Result<Bucket> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket().create(new_bucket))
+    }
+
+    /// Returns all `Bucket`s within this project.
+    ///
+    /// ### Note
+    /// When using incorrect permissions, this function fails silently and returns an empty list.
+    ///
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::new()?;
+    /// let buckets = client.bucket().list()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(&self) -> crate::Result<Vec<Bucket>> {
+        self.0.runtime.block_on(self.0.client.bucket().list())
+    }
+
+    /// Returns a single `Bucket` by its name. If the Bucket does not exist, an error is returned.
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::new()?;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-2".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket)?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-2")?;
+    /// # client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read(&self, name: &str) -> crate::Result<Bucket> {
+        self.0.runtime.block_on(self.0.client.bucket().read(name))
+    }
+
+    /// Update an existing `Bucket`. If you declare you bucket as mutable, you can edit its fields.
+    /// You can then flush your changes to Google Cloud Storage using this method.
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket::{Bucket, RetentionPolicy};
+    ///
+    /// let client = Client::new()?;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-3".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket)?;
+    ///
+    /// let mut bucket = client.bucket().read("cloud-storage-rs-doc-3")?;
+    /// bucket.retention_policy = Some(RetentionPolicy {
+    ///     retention_period: 50,
+    ///     effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+    ///     is_locked: Some(false),
+    /// });
+    /// client.bucket().update(&bucket)?;
+    /// # client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn update(&self, bucket: &Bucket) -> crate::Result<Bucket> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket().update(bucket))
+    }
+
+    /// Delete an existing `Bucket`. This permanently removes a bucket from Google Cloud Storage.
+    /// An error is returned when you don't have sufficient permissions, or when the
+    /// `retention_policy` prevents you from deleting your Bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::new()?;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "unnecessary-bucket".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket)?;
+    ///
+    /// let bucket = client.bucket().read("unnecessary-bucket")?;
+    /// client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete(&self, bucket: Bucket) -> crate::Result<()> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket().delete(bucket))
+    }
+
+    /// Returns the [IAM Policy](https://cloud.google.com/iam/docs/) for this bucket.
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::new()?;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-4".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket)?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-4")?;
+    /// let policy = client.bucket().get_iam_policy(&bucket)?;
+    /// # client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_iam_policy(&self, bucket: &Bucket) -> crate::Result<IamPolicy> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket().get_iam_policy(bucket))
+    }
+
+    /// Updates the [IAM Policy](https://cloud.google.com/iam/docs/) for this bucket.
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    /// use cloud_storage::bucket::{IamPolicy, Binding, IamRole, StandardIamRole, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-5".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket)?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-5")?;
+    /// let iam_policy = IamPolicy {
+    ///     version: 1,
+    ///     bindings: vec![
+    ///         Binding {
+    ///             role: IamRole::Standard(StandardIamRole::ObjectViewer),
+    ///             members: vec!["allUsers".to_string()],
+    ///             condition: None,
+    ///         }
+    ///     ],
+    ///     ..Default::default()
+    /// };
+    /// let policy = client.bucket().set_iam_policy(&bucket, &iam_policy)?;
+    /// # client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn set_iam_policy(&self, bucket: &Bucket, iam: &IamPolicy) -> crate::Result<IamPolicy> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket().set_iam_policy(bucket, iam))
+    }
+
+    /// Checks whether the user provided in the service account has this permission.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::new()?;
+    /// let bucket = client.bucket().read("my-bucket")?;
+    /// client.bucket().test_iam_permission(&bucket, "storage.buckets.get")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn test_iam_permission(
+        &self,
+        bucket: &Bucket,
+        permission: &str,
+    ) -> crate::Result<TestIamPermission> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .bucket()
+                .test_iam_permission(bucket, permission),
+        )
+    }
+}

--- a/vendor/cloud-storage-rs/src/sync/bucket_access_control.rs
+++ b/vendor/cloud-storage-rs/src/sync/bucket_access_control.rs
@@ -1,0 +1,147 @@
+use crate::bucket_access_control::{BucketAccessControl, Entity, NewBucketAccessControl};
+
+/// Operations on [`BucketAccessControl`](BucketAccessControl)s.
+#[derive(Debug)]
+pub struct BucketAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> BucketAccessControlClient<'a> {
+    /// Create a new `BucketAccessControl` using the provided `NewBucketAccessControl`, related to
+    /// the `Bucket` provided by the `bucket_name` argument.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, NewBucketAccessControl};
+    /// use cloud_storage::bucket_access_control::{Role, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let new_bucket_access_control = NewBucketAccessControl {
+    ///     entity: Entity::AllUsers,
+    ///     role: Role::Reader,
+    /// };
+    /// client.bucket_access_control().create("mybucket", &new_bucket_access_control)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create(
+        &self,
+        bucket: &str,
+        new_bucket_access_control: &NewBucketAccessControl,
+    ) -> crate::Result<BucketAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .bucket_access_control()
+                .create(bucket, new_bucket_access_control),
+        )
+    }
+
+    /// Returns all `BucketAccessControl`s related to this bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket_access_control::BucketAccessControl;
+    ///
+    /// let client = Client::new()?;
+    /// let acls = client.bucket_access_control().list("mybucket")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(&self, bucket: &str) -> crate::Result<Vec<BucketAccessControl>> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket_access_control().list(bucket))
+    }
+
+    /// Returns the ACL entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let controls = client.bucket_access_control().read("mybucket", &Entity::AllUsers)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read(&self, bucket: &str, entity: &Entity) -> crate::Result<BucketAccessControl> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket_access_control().read(bucket, entity))
+    }
+
+    /// Update this `BucketAccessControl`.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let mut acl = client.bucket_access_control().read("mybucket", &Entity::AllUsers)?;
+    /// acl.entity = Entity::AllAuthenticatedUsers;
+    /// client.bucket_access_control().update(&acl)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn update(
+        &self,
+        bucket_access_control: &BucketAccessControl,
+    ) -> crate::Result<BucketAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .bucket_access_control()
+                .update(bucket_access_control),
+        )
+    }
+
+    /// Permanently deletes the ACL entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let controls = client.bucket_access_control().read("mybucket", &Entity::AllUsers)?;
+    /// client.bucket_access_control().delete(controls)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete(&self, bucket_access_control: BucketAccessControl) -> crate::Result<()> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .bucket_access_control()
+                .delete(bucket_access_control),
+        )
+    }
+}

--- a/vendor/cloud-storage-rs/src/sync/default_object_access_control.rs
+++ b/vendor/cloud-storage-rs/src/sync/default_object_access_control.rs
@@ -1,0 +1,156 @@
+use crate::{
+    bucket_access_control::Entity,
+    default_object_access_control::{DefaultObjectAccessControl, NewDefaultObjectAccessControl},
+};
+
+/// Operations on [`DefaultObjectAccessControl`](DefaultObjectAccessControl)s.
+#[derive(Debug)]
+pub struct DefaultObjectAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> DefaultObjectAccessControlClient<'a> {
+    /// Create a new `DefaultObjectAccessControl` entry on the specified bucket.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::default_object_access_control::{
+    ///     DefaultObjectAccessControl, NewDefaultObjectAccessControl, Role, Entity,
+    /// };
+    ///
+    /// let client = Client::new()?;
+    /// let new_acl = NewDefaultObjectAccessControl {
+    ///     entity: Entity::AllAuthenticatedUsers,
+    ///     role: Role::Reader,
+    /// };
+    /// let default_acl = client.default_object_access_control().create("mybucket", &new_acl)?;
+    /// # client.default_object_access_control().delete(default_acl)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create(
+        &self,
+        bucket: &str,
+        new_acl: &NewDefaultObjectAccessControl,
+    ) -> crate::Result<DefaultObjectAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .default_object_access_control()
+                .create(bucket, new_acl),
+        )
+    }
+
+    /// Retrieves default object ACL entries on the specified bucket.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::default_object_access_control::DefaultObjectAccessControl;
+    ///
+    /// let client = Client::new()?;
+    /// let default_acls = client.default_object_access_control().list("mybucket")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(&self, bucket: &str) -> crate::Result<Vec<DefaultObjectAccessControl>> {
+        self.0
+            .runtime
+            .block_on(self.0.client.default_object_access_control().list(bucket))
+    }
+
+    /// Read a single `DefaultObjectAccessControl`.
+    /// The `bucket` argument is the name of the bucket whose `DefaultObjectAccessControl` is to be
+    /// read, and the `entity` argument is the entity holding the permission. Options are
+    /// Can be "user-`userId`", "user-`email_address`", "group-`group_id`", "group-`email_address`",
+    /// "allUsers", or "allAuthenticatedUsers".
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let default_acl = client.default_object_access_control().read("mybucket", &Entity::AllUsers)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read(&self, bucket: &str, entity: &Entity) -> crate::Result<DefaultObjectAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .default_object_access_control()
+                .read(bucket, entity),
+        )
+    }
+
+    /// Update the current `DefaultObjectAccessControl`.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let mut default_acl = client.default_object_access_control().read("my_bucket", &Entity::AllUsers)?;
+    /// default_acl.entity = Entity::AllAuthenticatedUsers;
+    /// client.default_object_access_control().update(&default_acl)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn update(
+        &self,
+        default_object_access_control: &DefaultObjectAccessControl,
+    ) -> crate::Result<DefaultObjectAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .default_object_access_control()
+                .update(default_object_access_control),
+        )
+    }
+
+    /// Delete this 'DefaultObjectAccessControl`.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let mut default_acl = client.default_object_access_control().read("my_bucket", &Entity::AllUsers)?;
+    /// client.default_object_access_control().delete(default_acl)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete(
+        &self,
+        default_object_access_control: DefaultObjectAccessControl,
+    ) -> Result<(), crate::Error> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .default_object_access_control()
+                .delete(default_object_access_control),
+        )
+    }
+}

--- a/vendor/cloud-storage-rs/src/sync/hmac_key.rs
+++ b/vendor/cloud-storage-rs/src/sync/hmac_key.rs
@@ -1,0 +1,130 @@
+use crate::hmac_key::{HmacKey, HmacMeta, HmacState};
+
+/// Operations on [`HmacKey`](HmacKey)s.
+#[derive(Debug)]
+pub struct HmacKeyClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> HmacKeyClient<'a> {
+    /// Creates a new HMAC key for the specified service account.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.create` permission for the project in
+    /// which the key will be created.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::new()?;
+    /// let hmac_key = client.hmac_key().create()?;
+    /// # use cloud_storage::hmac_key::HmacState;
+    /// # client.hmac_key().update(&hmac_key.metadata.access_id, HmacState::Inactive)?;
+    /// # client.hmac_key().delete(&hmac_key.metadata.access_id)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create(&self) -> crate::Result<HmacKey> {
+        self.0.runtime.block_on(self.0.client.hmac_key().create())
+    }
+
+    /// Retrieves a list of HMAC keys matching the criteria. Since the HmacKey is secret, this does
+    /// not return a `HmacKey`, but a `HmacMeta`. This is a redacted version of a `HmacKey`, but
+    /// with the secret data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.list` permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::new()?;
+    /// let all_hmac_keys = client.hmac_key().list()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(&self) -> crate::Result<Vec<HmacMeta>> {
+        self.0.runtime.block_on(self.0.client.hmac_key().list())
+    }
+
+    /// Retrieves an HMAC key's metadata. Since the HmacKey is secret, this does not return a
+    /// `HmacKey`, but a `HmacMeta`. This is a redacted version of a `HmacKey`, but with the secret
+    /// data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.get` permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::new()?;
+    /// let key = client.hmac_key().read("some identifier")?;
+    /// # Ok(())
+    /// # }
+    pub fn read(&self, access_id: &str) -> crate::Result<HmacMeta> {
+        self.0
+            .runtime
+            .block_on(self.0.client.hmac_key().read(access_id))
+    }
+
+    /// Updates the state of an HMAC key. See the HMAC Key resource descriptor for valid states.
+    /// Since the HmacKey is secret, this does not return a `HmacKey`, but a `HmacMeta`. This is a
+    /// redacted version of a `HmacKey`, but with the secret data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.update` permission for the project in
+    /// which the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::hmac_key::{HmacKey, HmacState};
+    ///
+    /// let client = Client::new()?;
+    /// let key = client.hmac_key().update("your key", HmacState::Active)?;
+    /// # Ok(())
+    /// # }
+    pub fn update(&self, access_id: &str, state: HmacState) -> crate::Result<HmacMeta> {
+        self.0
+            .runtime
+            .block_on(self.0.client.hmac_key().update(access_id, state))
+    }
+
+    /// Deletes an HMAC key. Note that a key must be set to `Inactive` first.
+    ///
+    /// The authenticated user must have storage.hmacKeys.delete permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::hmac_key::{HmacKey, HmacState};
+    ///
+    /// let client = Client::new()?;
+    /// let key = client.hmac_key().update("your key", HmacState::Inactive)?; // this is required.
+    /// client.hmac_key().delete(&key.access_id)?;
+    /// # Ok(())
+    /// # }
+    pub fn delete(&self, access_id: &str) -> crate::Result<()> {
+        self.0
+            .runtime
+            .block_on(self.0.client.hmac_key().delete(access_id))
+    }
+}

--- a/vendor/cloud-storage-rs/src/sync/object.rs
+++ b/vendor/cloud-storage-rs/src/sync/object.rs
@@ -1,0 +1,273 @@
+use crate::{
+    object::{ComposeRequest, ObjectList},
+    ListRequest, Object,
+};
+use futures::TryStreamExt;
+
+/// Operations on [`Object`](Object)s.
+#[derive(Debug)]
+pub struct ObjectClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> ObjectClient<'a> {
+    /// Create a new object.
+    /// Upload a file as that is loaded in memory to google cloud storage, where it will be
+    /// interpreted according to the mime type you specified.
+    /// ## Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn read_cute_cat(_in: &str) -> Vec<u8> { vec![0, 1] }
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let file: Vec<u8> = read_cute_cat("cat.png");
+    /// let client = Client::new()?;
+    /// client.object().create("cat-photos", file, "recently read cat.png", "image/png")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create(
+        &self,
+        bucket: &str,
+        file: Vec<u8>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Object> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object()
+                .create(bucket, file, filename, mime_type),
+        )
+    }
+
+    /// Create a new object. This works in the same way as `ObjectClient::create`, except it does not need
+    /// to load the entire file in ram.
+    pub fn create_streamed<R>(
+        &self,
+        bucket: &str,
+        mut file: R,
+        length: impl Into<Option<u64>>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Object>
+    where
+        R: std::io::Read + Send + 'static,
+    {
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer)
+            .map_err(|e| crate::Error::Other(e.to_string()))?;
+
+        let stream = futures::stream::once(async { Ok::<_, crate::Error>(buffer) });
+
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object()
+                .create_streamed(bucket, stream, length, filename, mime_type),
+        )
+    }
+
+    /// Obtain a list of objects within this Bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::{Object, ListRequest};
+    ///
+    /// let client = Client::new()?;
+    /// let all_objects = client.object().list("my_bucket", ListRequest::default())?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(
+        &self,
+        bucket: &'a str,
+        list_request: ListRequest,
+    ) -> crate::Result<Vec<ObjectList>> {
+        let rt = &self.0.runtime;
+        let listed = rt.block_on(self.0.client.object().list(bucket, list_request))?;
+        rt.block_on(listed.try_collect())
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::new()?;
+    /// let object = client.object().read("my_bucket", "path/to/my/file.png")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read(&self, bucket: &str, file_name: &str) -> crate::Result<Object> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object().read(bucket, file_name))
+    }
+
+    /// Download the content of the object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::new()?;
+    /// let bytes = client.object().download("my_bucket", "path/to/my/file.png")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn download(&self, bucket: &str, file_name: &str) -> crate::Result<Vec<u8>> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object().download(bucket, file_name))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::new()?;
+    /// let mut object = client.object().read("my_bucket", "path/to/my/file.png")?;
+    /// object.content_type = Some("application/xml".to_string());
+    /// client.object().update(&object)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn update(&self, object: &Object) -> crate::Result<Object> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object().update(object))
+    }
+
+    /// Deletes a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::new()?;
+    /// client.object().delete("my_bucket", "path/to/my/file.png")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete(&self, bucket: &str, file_name: &str) -> crate::Result<()> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object().delete(bucket, file_name))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::object::{Object, ComposeRequest, SourceObject};
+    ///
+    /// let client = Client::new()?;
+    /// let obj1 = client.object().read("my_bucket", "file1")?;
+    /// let obj2 = client.object().read("my_bucket", "file2")?;
+    /// let compose_request = ComposeRequest {
+    ///     kind: "storage#composeRequest".to_string(),
+    ///     source_objects: vec![
+    ///         SourceObject {
+    ///             name: obj1.name.clone(),
+    ///             generation: None,
+    ///             object_preconditions: None,
+    ///         },
+    ///         SourceObject {
+    ///             name: obj2.name.clone(),
+    ///             generation: None,
+    ///             object_preconditions: None,
+    ///         },
+    ///     ],
+    ///     destination: None,
+    /// };
+    /// let obj3 = client.object().compose("my_bucket", &compose_request, "test-concatted-file")?;
+    /// // obj3 is now a file with the content of obj1 and obj2 concatted together.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn compose(
+        &self,
+        bucket: &str,
+        req: &ComposeRequest,
+        destination_object: &str,
+    ) -> crate::Result<Object> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object()
+                .compose(bucket, req, destination_object),
+        )
+    }
+
+    /// Copy this object to the target bucket and path
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::object::{Object, ComposeRequest};
+    ///
+    /// let client = Client::new()?;
+    /// let obj1 = client.object().read("my_bucket", "file1")?;
+    /// let obj2 = client.object().copy(&obj1, "my_other_bucket", "file2")?;
+    /// // obj2 is now a copy of obj1.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn copy(
+        &self,
+        object: &Object,
+        destination_bucket: &str,
+        path: &str,
+    ) -> crate::Result<Object> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object()
+                .copy(object, destination_bucket, path),
+        )
+    }
+
+    /// Moves a file from the current location to the target bucket and path.
+    ///
+    /// ## Limitations
+    /// This function does not yet support rewriting objects to another
+    /// * Geographical Location,
+    /// * Encryption,
+    /// * Storage class.
+    /// These limitations mean that for now, the rewrite and the copy methods do the same thing.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::object::Object;
+    ///
+    /// let client = Client::new()?;
+    /// let obj1 = client.object().read("my_bucket", "file1")?;
+    /// let obj2 = client.object().rewrite(&obj1, "my_other_bucket", "file2")?;
+    /// // obj2 is now a copy of obj1.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn rewrite(
+        &self,
+        object: &Object,
+        destination_bucket: &str,
+        path: &str,
+    ) -> crate::Result<Object> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object()
+                .rewrite(object, destination_bucket, path),
+        )
+    }
+}

--- a/vendor/cloud-storage-rs/src/sync/object_access_control.rs
+++ b/vendor/cloud-storage-rs/src/sync/object_access_control.rs
@@ -1,0 +1,96 @@
+use crate::{
+    bucket_access_control::Entity,
+    object_access_control::{NewObjectAccessControl, ObjectAccessControl},
+};
+
+/// Operations on [`ObjectAccessControl`](ObjectAccessControl)s.
+#[derive(Debug)]
+pub struct ObjectAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> ObjectAccessControlClient<'a> {
+    /// Creates a new ACL entry on the specified `object`.
+    ///
+    /// ### Important
+    /// This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub fn create(
+        &self,
+        bucket: &str,
+        object: &str,
+        new_object_access_control: &NewObjectAccessControl,
+    ) -> crate::Result<ObjectAccessControl> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object_access_control().create(
+                bucket,
+                object,
+                new_object_access_control,
+            ))
+    }
+
+    /// Retrieves `ACL` entries on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub fn list(&self, bucket: &str, object: &str) -> crate::Result<Vec<ObjectAccessControl>> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object_access_control().list(bucket, object))
+    }
+
+    /// Returns the `ACL` entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub fn read(
+        &self,
+        bucket: &str,
+        object: &str,
+        entity: &Entity,
+    ) -> crate::Result<ObjectAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object_access_control()
+                .read(bucket, object, entity),
+        )
+    }
+
+    /// Updates an ACL entry on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub fn update(
+        &self,
+        object_access_control: &ObjectAccessControl,
+    ) -> crate::Result<ObjectAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object_access_control()
+                .update(object_access_control),
+        )
+    }
+
+    /// Permanently deletes the ACL entry for the specified entity on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub fn delete(&self, object_access_control: ObjectAccessControl) -> crate::Result<()> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object_access_control()
+                .delete(object_access_control),
+        )
+    }
+}

--- a/vendor/cloud-storage-rs/src/token.rs
+++ b/vendor/cloud-storage-rs/src/token.rs
@@ -1,0 +1,88 @@
+use crate::error::Error;
+use serde::{Deserialize, Serialize};
+
+/// This struct contains contains a token, an expiry, and an access scope.
+pub struct Token {
+    // this field contains the JWT and the expiry thereof. They are in the same Option because if
+    // one of them is `Some`, we require that the other be `Some` as well.
+    token: Option<(String, u64)>,
+    // store the access scope for later use if we need to refresh the token
+    access_scope: String,
+}
+
+#[derive(Serialize)]
+struct Claims {
+    iss: String,
+    scope: String,
+    aud: String,
+    exp: u64,
+    iat: u64,
+}
+
+#[derive(Deserialize, Debug)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: usize,
+    token_type: String,
+}
+
+impl Token {
+    pub fn new(scope: &str) -> Self {
+        Self {
+            token: None,
+            access_scope: scope.to_string(),
+        }
+    }
+
+    pub async fn get(&mut self) -> crate::Result<String> {
+        match self.token {
+            Some((ref token, exp)) if exp > now() => Ok(token.clone()),
+            _ => self.retrieve().await,
+        }
+    }
+
+    async fn retrieve(&mut self) -> crate::Result<String> {
+        self.token = Some(Self::get_token(&self.access_scope).await?);
+        match self.token {
+            Some(ref token) => Ok(token.0.clone()),
+            None => unreachable!(),
+        }
+    }
+
+    async fn get_token(scope: &str) -> Result<(String, u64), Error> {
+        let now = now();
+        let exp = now + 3600;
+
+        let claims = Claims {
+            iss: crate::SERVICE_ACCOUNT.client_email.clone(),
+            scope: scope.into(),
+            aud: "https://www.googleapis.com/oauth2/v4/token".to_string(),
+            exp,
+            iat: now,
+        };
+        let mut header = jsonwebtoken::Header::default();
+        header.alg = jsonwebtoken::Algorithm::RS256;
+        let private_key_bytes = crate::SERVICE_ACCOUNT.private_key.as_bytes();
+        let private_key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key_bytes)?;
+        let jwt = jsonwebtoken::encode(&header, &claims, &private_key)?;
+        let body = [
+            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("assertion", &jwt),
+        ];
+        let response: TokenResponse = reqwest::Client::new()
+            .post("https://www.googleapis.com/oauth2/v4/token")
+            .form(&body)
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok((response.access_token, exp))
+    }
+}
+
+fn now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}

--- a/vendor/cloud-storage-rs/src/token.rs
+++ b/vendor/cloud-storage-rs/src/token.rs
@@ -60,8 +60,10 @@ impl Token {
             exp,
             iat: now,
         };
-        let mut header = jsonwebtoken::Header::default();
-        header.alg = jsonwebtoken::Algorithm::RS256;
+        let header = jsonwebtoken::Header{
+            alg: jsonwebtoken::Algorithm::RS256,
+            ..Default::default()
+        };
         let private_key_bytes = crate::SERVICE_ACCOUNT.private_key.as_bytes();
         let private_key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key_bytes)?;
         let jwt = jsonwebtoken::encode(&header, &claims, &private_key)?;


### PR DESCRIPTION
* includes stub for redis remote cache management

## Description

This vendors `cloud-storage-rs:0-6.2` so that we can try to add precondition headers to storage requests.

## Testing

Unit test included. 
You can also test this by using a script like 
```bash
GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/sync-spanner-dev.json \
TEST_PROJECT=project-name \
TEST_BUCKET=bucket-name \
cargo test $* -- --no-capture
```
There are two `test_image_proc` tests which should try to load a new image into the bucket (you should manually remove the image after the test). 

## Issue(s)

Closes [link](link).
