### PR TITLE
Upgrade the Docker images for contile-integration-tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   partner:
-    image: mozilla/contile-integration-tests-partner:21.3.0
+    image: mozilla/contile-integration-tests-partner:21.4.0
     container_name: partner
     environment:
       PORT: 5000
@@ -44,7 +44,7 @@ services:
     #entrypoint: >
     #  /bin/sh -c "hostname -I && bin/contile"
   client:
-    image: mozilla/contile-integration-tests-client:21.3.0
+    image: mozilla/contile-integration-tests-client:21.4.0
     container_name: client
     depends_on:
       - partner


### PR DESCRIPTION
## Description

The **21.4.0** release of **contile-integration-tests** adds the following new capabilities to the partner API:
- Return a `400 Bad Request` for extra query parameters
- Validation for the `region-code` query parameter
- Add optional `dma-code` query parameter to API

See https://github.com/mozilla-services/contile-integration-tests/releases/tag/21.4.0

## Testing

Verify that new pull requests use the new Docker images.

## Issue(s)

NA
