### PR TITLE
Upgrade the Docker images for contile-integration-tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: partner
     environment:
       PORT: 5000
-      RESPONSES_FILE: /tmp/partner/responses.yml
+      RESPONSES_DIR: /tmp/partner/
     expose:
       - "5000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   partner:
-    image: mozilla/contile-integration-tests-partner:21.4.0
+    image: mozilla/contile-integration-tests-partner:21.5.0
     container_name: partner
     environment:
       PORT: 5000
@@ -44,7 +44,7 @@ services:
     #entrypoint: >
     #  /bin/sh -c "hostname -I && bin/contile"
   client:
-    image: mozilla/contile-integration-tests-client:21.4.0
+    image: mozilla/contile-integration-tests-client:21.5.0
     container_name: client
     depends_on:
       - partner


### PR DESCRIPTION
## Description

The **21.5.0** release of **contile-integration-tests** adds support for multiple responses files to the partner API.

See https://github.com/mozilla-services/contile-integration-tests/releases/tag/21.5.0

## Testing

Verify that new pull requests use the new Docker images.

## Issue(s)

NA
