### PR TITLE
Add integration test for different regions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     links:
       - partner
     environment:
+      CONTILE_MAXMINDDB_LOC: /tmp/mmdb/GeoLite2-City-Test.mmdb
       CONTILE_ADM_ENDPOINT_URL: http://partner:5000/tilesp
       CONTILE_ADM_QUERY_TILE_COUNT: 2
       CONTILE_ADM_SETTINGS: /tmp/contile/adm_settings.json
@@ -36,6 +37,7 @@ services:
       - "8000"
     volumes:
       - ./tools/volumes/contile:/tmp/contile
+      - ./mmdb:/tmp/mmdb
     ## Override the entrypoint to report the IP address, then try
     ## running Contile this can be useful to debug internal
     ## networking issues as well as externally connect to contile.

--- a/tools/volumes/client/scenarios.yml
+++ b/tools/volumes/client/scenarios.yml
@@ -182,3 +182,41 @@ scenarios:
         response:
           status_code: 403 # Forbidden
           content: 700
+
+  - name: success_country_code_region_code
+    description: Test that Contile successfully returns tiles for a specific country and region.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: macos and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 Firefox/91.0'
+            # Contile looks up the IP address from this header value and maps it to proxy information.
+            # We use a random IP address from the range specified by the CIDR network notation "216.160.83.56/29"
+            # from https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json
+            # The following value will result in country-code: US and region-code: WA
+            - name: X-Forwarded-For
+              value: '216.160.83.62'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 22346
+                name: 'Example COM'
+                click_url: 'https://example.com/us_wa_desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/us_wa_desktop_macos01.jpg'
+                image_size: null
+                impression_url: 'https://example.com/us_wa_desktop_macos?id=0001'
+                url: 'https://www.example.com/us_wa_desktop_macos'
+                position: 1
+              - id: 56790
+                name: 'Example ORG'
+                click_url: 'https://example.org/us_wa_desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/us_wa_desktop_macos02.jpg'
+                image_size: null
+                impression_url: 'https://example.org/us_wa_desktop_macos?id=0002'
+                url: 'https://www.example.org/us_wa_desktop_macos'
+                position: 1

--- a/tools/volumes/partner/US/WA.yml
+++ b/tools/volumes/partner/US/WA.yml
@@ -1,0 +1,56 @@
+# This file contains partner responses for US-WA for the /tilesp API endpoint.
+# We use form-factor and os-family to determine which response to send to Contile.
+desktop:
+    windows:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 22345
+            name: 'Example COM'
+            click_url: 'https://example.com/us_wa_desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/us_wa_desktop_windows01.jpg'
+            impression_url: 'https://example.com/us_wa_desktop_windows?id=0001'
+            advertiser_url: 'https://www.example.com/us_wa_desktop_windows'
+          - id: 66789
+            name: 'Example ORG'
+            click_url: 'https://example.org/us_wa_desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/us_wa_desktop_windows02.jpg'
+            impression_url: 'https://example.org/us_wa_desktop_windows?id=0002'
+            advertiser_url: 'https://www.example.org/us_wa_desktop_windows'
+
+    macos:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 22346
+            name: 'Example COM'
+            click_url: 'https://example.com/us_wa_desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/us_wa_desktop_macos01.jpg'
+            impression_url: 'https://example.com/us_wa_desktop_macos?id=0001'
+            advertiser_url: 'https://www.example.com/us_wa_desktop_macos'
+          - id: 56790
+            name: 'Example ORG'
+            click_url: 'https://example.org/us_wa_desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/us_wa_desktop_macos02.jpg'
+            impression_url: 'https://example.org/us_wa_desktop_macos?id=0002'
+            advertiser_url: 'https://www.example.org/us_wa_desktop_macos'
+
+    linux:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 22347
+            name: 'Example COM'
+            click_url: 'https://example.com/us_wa_desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/us_wa_desktop_linux01.jpg'
+            impression_url: 'https://example.com/us_wa_desktop_linux?id=0001'
+            advertiser_url: 'https://www.example.com/us_wa_desktop_linux'
+          - id: 66791
+            name: 'Example ORG'
+            click_url: 'https://example.org/us_wa_desktop_linux?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/us_wa_desktop_linux02.jpg'
+            impression_url: 'https://example.org/us_wa_desktop_linux?id=0002'
+            advertiser_url: 'https://www.example.org/us_wa_desktop_linux'


### PR DESCRIPTION
## Description

This pull request adds a new integration test to verify that Contile successfully returns tiles for a specific country and region.

The integration test docker-compose now mounts the `GeoLite2-City-Test.mmdb` database, which we also use for unit tests, in the Contile Docker container and sets the `X-Forwarded-For` request HTTP header to a random IP address from the range specified by the CIDR network notation in [GeoLite2-City-Test.json](https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json) for `US-WA`.

## Testing

Verify that the new test `success_country_code_region_code` runs on CI.

## Issue(s)

NA
