### PR TITLE
chore: API Updates for 2021-08-19

### DIFF
--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -138,6 +138,7 @@ pub async fn get_tiles(
         &[
             ("partner", settings.adm_partner_id.clone().unwrap().as_str()),
             ("sub1", settings.adm_sub1.clone().unwrap().as_str()),
+            ("sub2", "newtab"),
             (
                 "country-code",
                 &(location
@@ -146,14 +147,14 @@ pub async fn get_tiles(
                     .unwrap_or_else(|| settings.fallback_country.clone())),
             ),
             ("region-code", &location.region()),
-            ("form-factor", &device_info.form_factor.to_string()),
-            ("os-family", &device_info.os_family.to_string()),
             (
                 "dma-code",
                 &filtered_dma(&state.excluded_dmas, &location.dma()),
             ),
-            ("sub2", "newtab"),
+            ("form-factor", &device_info.form_factor.to_string()),
+            ("os-family", &device_info.os_family.to_string()),
             ("v", "1.0"),
+            ("out", "json"), // not technically needed, but added for paranoid reasons.
             // XXX: some value for results seems required, it defaults to 0
             // when omitted (despite AdM claiming it would default to 1)
             ("results", &settings.adm_query_tile_count.to_string()),

--- a/src/server/cache.rs
+++ b/src/server/cache.rs
@@ -9,7 +9,7 @@ use std::{
 use cadence::StatsdClient;
 use dashmap::DashMap;
 
-use crate::{adm::TileResponse, error::HandlerError, metrics::Metrics, web::FormFactor};
+use crate::{adm::TileResponse, error::HandlerError, metrics::Metrics, web::{FormFactor, OsFamily}};
 
 /// AudienceKey is the primary key used to store and fetch tiles from the
 /// local cache.
@@ -23,6 +23,8 @@ pub struct AudienceKey {
     pub dma_code: Option<u16>,
     /// The form-factor (e.g. desktop, phone) of the device
     pub form_factor: FormFactor,
+    /// Platform OS
+    pub os_family: OsFamily,
     /// Only serve legacy
     pub legacy_only: bool,
 }

--- a/src/server/cache.rs
+++ b/src/server/cache.rs
@@ -9,7 +9,12 @@ use std::{
 use cadence::StatsdClient;
 use dashmap::DashMap;
 
-use crate::{adm::TileResponse, error::HandlerError, metrics::Metrics, web::{FormFactor, OsFamily}};
+use crate::{
+    adm::TileResponse,
+    error::HandlerError,
+    metrics::Metrics,
+    web::{FormFactor, OsFamily},
+};
 
 /// AudienceKey is the primary key used to store and fetch tiles from the
 /// local cache.

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -69,6 +69,7 @@ pub async fn get_tiles(
         },
         dma_code: location.dma,
         form_factor: device_info.form_factor,
+        os_family: device_info.os_family,
         legacy_only: device_info.legacy_only(),
     };
 

--- a/tools/volumes/client/scenarios.yml
+++ b/tools/volumes/client/scenarios.yml
@@ -59,8 +59,8 @@ scenarios:
                 url: 'https://www.example.org/desktop_windows'
                 position: 1
 
-  - name: success_desktop_macos_cached_from_windows
-    description: Test that Contile successfully returns cached Windows tiles for macOS on Desktop.
+  - name: success_desktop_macos
+    description: Test that Contile successfully returns tiles for macOS on Desktop.
     steps:
       - request:
           method: GET
@@ -74,25 +74,25 @@ scenarios:
           status_code: 200
           content:
             tiles:
-              - id: 12345
+              - id: 12346
                 name: 'Example COM'
-                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
-                image_url: 'https://example.com/desktop_windows01.jpg'
+                click_url: 'https://example.com/desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/desktop_macos01.jpg'
                 image_size: null
-                impression_url: 'https://example.com/desktop_windows?id=0001'
-                url: 'https://www.example.com/desktop_windows'
+                impression_url: 'https://example.com/desktop_macos?id=0001'
+                url: 'https://www.example.com/desktop_macos'
                 position: 1
-              - id: 56789
+              - id: 56790
                 name: 'Example ORG'
-                click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-                image_url: 'https://example.org/desktop_windows02.jpg'
+                click_url: 'https://example.org/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/desktop_macos02.jpg'
                 image_size: null
-                impression_url: 'https://example.org/desktop_windows?id=0002'
-                url: 'https://www.example.org/desktop_windows'
+                impression_url: 'https://example.org/desktop_macos?id=0002'
+                url: 'https://www.example.org/desktop_macos'
                 position: 1
 
-  - name: success_desktop_linux_cached_from_windows
-    description: Test that Contile successfully returns cached Windows tiles for Linux on Desktop.
+  - name: success_desktop_linux
+    description: Test that Contile returns tiles for Linux on Desktop.
     steps:
       - request:
           method: GET
@@ -106,21 +106,21 @@ scenarios:
           status_code: 200
           content:
             tiles:
-              - id: 12345
+              - id: 12347
                 name: 'Example COM'
-                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
-                image_url: 'https://example.com/desktop_windows01.jpg'
+                click_url: 'https://example.com/desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/desktop_linux01.jpg'
                 image_size: null
-                impression_url: 'https://example.com/desktop_windows?id=0001'
-                url: 'https://www.example.com/desktop_windows'
+                impression_url: 'https://example.com/desktop_linux?id=0001'
+                url: 'https://www.example.com/desktop_linux'
                 position: 1
-              - id: 56789
+              - id: 56791
                 name: 'Example ORG'
-                click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-                image_url: 'https://example.org/desktop_windows02.jpg'
+                click_url: 'https://example.org/desktop_linux?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/desktop_linux02.jpg'
                 image_size: null
-                impression_url: 'https://example.org/desktop_windows?id=0002'
-                url: 'https://www.example.org/desktop_windows'
+                impression_url: 'https://example.org/desktop_linux?id=0002'
+                url: 'https://www.example.org/desktop_linux'
                 position: 1
 
   - name: error_phone_android_reqwest_error


### PR DESCRIPTION
## Description

* Adds `OsFamily` to cache key
* Adds `out=json` to outbound query (to avoid future issues).
* sorted query params to match API list.

## Testing

@hackebrot: This [includes the latest parameters](https://github.com/mozilla-services/contile/compare/feat/api-2021-08-19?expand=1#diff-5f4dcf145cf76636816065a49a2fbc0e4a52624a4c2109f3547ed1bbb8fa26d7) in the aDM API calls. Integration tests may need modification.

## Issue(s)

Closes #268

