### PR TITLE
Add integration test for legacy image filter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     environment:
       CONTILE_MAXMINDDB_LOC: /tmp/mmdb/GeoLite2-City-Test.mmdb
       CONTILE_ADM_ENDPOINT_URL: http://partner:5000/tilesp
-      CONTILE_ADM_QUERY_TILE_COUNT: 2
+      CONTILE_ADM_QUERY_TILE_COUNT: 5
       CONTILE_ADM_SETTINGS: /tmp/contile/adm_settings.json
       CONTILE_ADM_HAS_LEGACY_IMAGE: '["Example ORG","Example COM"]'
       # Timeout requests to the ADM server after this many seconds (default: 5)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       CONTILE_ADM_ENDPOINT_URL: http://partner:5000/tilesp
       CONTILE_ADM_QUERY_TILE_COUNT: 2
       CONTILE_ADM_SETTINGS: /tmp/contile/adm_settings.json
+      CONTILE_ADM_HAS_LEGACY_IMAGE: '["Example ORG","Example COM"]'
       # Timeout requests to the ADM server after this many seconds (default: 5)
       CONTILE_ADM_TIMEOUT: 2
       CONTILE_DEBUG: 1

--- a/tools/volumes/client/scenarios.yml
+++ b/tools/volumes/client/scenarios.yml
@@ -220,3 +220,77 @@ scenarios:
                 impression_url: 'https://example.org/us_wa_desktop_macos?id=0002'
                 url: 'https://www.example.org/us_wa_desktop_macos'
                 position: 1
+
+  - name: legacy_image_filter
+    description: >
+      Test that Contile successfully filters tiles based on whether there's an
+      image for the ad provider of a tile shipped with Firefox 90.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: macos and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 Firefox/91.0'
+            # Contile looks up the IP address from this header value and maps it to proxy information.
+            # We use a random IP address from the range specified by the CIDR network notation "81.2.69.192/28"
+            # from https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json
+            # The following value will result in country-code: GB and region-code: ENG
+            - name: X-Forwarded-For
+              value: '81.2.69.204'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 41235
+                name: 'DunBroch'
+                click_url: 'https://dunbroch.co.uk/gb_desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://dunbroch.co.uk/gb_desktop_macos01.jpg'
+                image_size: null
+                impression_url: 'https://dunbroch.co.uk/gb_desktop_macos?id=0001'
+                url: 'https://www.dunbroch.co.uk/gb_desktop_macos'
+                position: 2
+              - id: 32346
+                name: 'Example COM'
+                click_url: 'https://example.com/gb_desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/gb_desktop_macos01.jpg'
+                image_size: null
+                impression_url: 'https://example.com/gb_desktop_macos?id=0001'
+                url: 'https://www.example.com/gb_desktop_macos'
+                position: 1
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: macos and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 Firefox/90.0'
+            # Contile looks up the IP address from this header value and maps it to proxy information.
+            # We use a random IP address from the range specified by the CIDR network notation "81.2.69.192/28"
+            # from https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json
+            # The following value will result in country-code: GB and region-code: ENG
+            - name: X-Forwarded-For
+              value: '81.2.69.192'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 32346
+                name: 'Example COM'
+                click_url: 'https://example.com/gb_desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/gb_desktop_macos01.jpg'
+                image_size: null
+                impression_url: 'https://example.com/gb_desktop_macos?id=0001'
+                url: 'https://www.example.com/gb_desktop_macos'
+                position: 1
+              - id: 76790
+                name: 'Example ORG'
+                click_url: 'https://example.org/gb_desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/gb_desktop_macos02.jpg'
+                image_size: null
+                impression_url: 'https://example.org/gb_desktop_macos?id=0002'
+                url: 'https://www.example.org/gb_desktop_macos'
+                position: 1

--- a/tools/volumes/contile/adm_settings.json
+++ b/tools/volumes/contile/adm_settings.json
@@ -30,6 +30,21 @@
         "include_regions": [],
         "position": 1
     },
+    "DunBroch": {
+        "advertiser_hosts": [
+            "www.dunbroch.co.uk"
+        ],
+        "click_hosts": [
+            "dunbroch.co.uk"
+        ],
+        "impression_hosts": [
+            "dunbroch.co.uk"
+        ],
+        "include_regions": [
+            "GB"
+        ],
+        "position": 2
+    },
     "DEFAULT": {
         "advertiser_hosts": [],
         "click_hosts": [

--- a/tools/volumes/partner/GB/responses.yml
+++ b/tools/volumes/partner/GB/responses.yml
@@ -1,0 +1,74 @@
+# This file contains partner responses for GB for the /tilesp API endpoint.
+# We use form-factor and os-family to determine which response to send to Contile.
+desktop:
+    windows:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 41234
+            name: 'DunBroch'
+            click_url: 'https://dunbroch.co.uk/gb_desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://dunbroch.co.uk/gb_desktop_windows01.jpg'
+            impression_url: 'https://dunbroch.co.uk/gb_desktop_windows?id=0001'
+            advertiser_url: 'https://www.dunbroch.co.uk/gb_desktop_windows'
+          - id: 32345
+            name: 'Example COM'
+            click_url: 'https://example.com/gb_desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/gb_desktop_windows01.jpg'
+            impression_url: 'https://example.com/gb_desktop_windows?id=0001'
+            advertiser_url: 'https://www.example.com/gb_desktop_windows'
+          - id: 76789
+            name: 'Example ORG'
+            click_url: 'https://example.org/gb_desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/gb_desktop_windows02.jpg'
+            impression_url: 'https://example.org/gb_desktop_windows?id=0002'
+            advertiser_url: 'https://www.example.org/gb_desktop_windows'
+
+    macos:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 41235
+            name: 'DunBroch'
+            click_url: 'https://dunbroch.co.uk/gb_desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://dunbroch.co.uk/gb_desktop_macos01.jpg'
+            impression_url: 'https://dunbroch.co.uk/gb_desktop_macos?id=0001'
+            advertiser_url: 'https://www.dunbroch.co.uk/gb_desktop_macos'
+          - id: 32346
+            name: 'Example COM'
+            click_url: 'https://example.com/gb_desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/gb_desktop_macos01.jpg'
+            impression_url: 'https://example.com/gb_desktop_macos?id=0001'
+            advertiser_url: 'https://www.example.com/gb_desktop_macos'
+          - id: 76790
+            name: 'Example ORG'
+            click_url: 'https://example.org/gb_desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/gb_desktop_macos02.jpg'
+            impression_url: 'https://example.org/gb_desktop_macos?id=0002'
+            advertiser_url: 'https://www.example.org/gb_desktop_macos'
+
+    linux:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 41236
+            name: 'DunBroch'
+            click_url: 'https://dunbroch.co.uk/gb_desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://dunbroch.co.uk/gb_desktop_linux01.jpg'
+            impression_url: 'https://dunbroch.co.uk/gb_desktop_linux?id=0001'
+            advertiser_url: 'https://www.dunbroch.co.uk/gb_desktop_linux'
+          - id: 32347
+            name: 'Example COM'
+            click_url: 'https://example.com/gb_desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/gb_desktop_linux01.jpg'
+            impression_url: 'https://example.com/gb_desktop_linux?id=0001'
+            advertiser_url: 'https://www.example.com/gb_desktop_linux'
+          - id: 76791
+            name: 'Example ORG'
+            click_url: 'https://example.org/gb_desktop_linux?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/gb_desktop_linux02.jpg'
+            impression_url: 'https://example.org/gb_desktop_linux?id=0002'
+            advertiser_url: 'https://www.example.org/gb_desktop_linux'


### PR DESCRIPTION
## Description

This pull request adds a new integration test to verify that Contile successfully filters tiles based on whether there's an image for the ad provider of a tile shipped with Firefox 90.

- I have added a new ad provider for testing named `DunBroch` which is only returned for in requests from `GB`
- Only `Example ORG` and `Example COM` have  legacy images (see `docker-compose.yml`)
- The first request in the new scenario comes from Firefox 91 and we expect tiles for `DunBroch` as well as `Example COM`
- The second request in the new scenario comes from Firefox 90 and we expect **no** tiles for `DunBroch`

See https://github.com/mozilla-services/contile-integration-tests/pull/64#pullrequestreview-732978460

## Testing

Verify that the new test `legacy_image_filter` runs on CI.

## Issue(s)

The feature under test was added in #247.
