### PR TITLE
Add integration tests for 200 OK for excluded countries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,11 +203,24 @@ jobs:
          name: Restore Docker image cache
          command: docker load -i /home/circleci/cache/docker.tar
       - run:
-         name: Run Integration tests
+         name: Log in to the default Docker registry
          command: |
            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+      - run:
+         name: Run integration tests
+         command: |
            docker-compose --version
-           docker-compose -f docker-compose.yml up --abort-on-container-exit
+           docker-compose \
+            -f docker-compose.yml \
+            up --abort-on-container-exit --force-recreate
+      - run:
+         name: Run additional integration tests
+         command: |
+           docker-compose --version
+           docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.204.yml \
+            up --abort-on-container-exit --force-recreate
 
 workflows:
   version: 2

--- a/docker-compose.204.yml
+++ b/docker-compose.204.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+  contile:
+    environment:
+      CONTILE_EXCLUDED_COUNTRIES_200: 0
+  client:
+    environment:
+      SCENARIOS_FILE: /tmp/client/scenarios_204.yml

--- a/tools/volumes/client/scenarios.yml
+++ b/tools/volumes/client/scenarios.yml
@@ -294,3 +294,25 @@ scenarios:
                 impression_url: 'https://example.org/gb_desktop_macos?id=0002'
                 url: 'https://www.example.org/gb_desktop_macos'
                 position: 1
+
+  - name: success_200_OK_exluded_region
+    description: Test that Contile returns a 200 OK with an empty tiles array for excluded regions
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: macos and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 Firefox/91.0'
+            # Contile looks up the IP address from this header value and maps it to proxy information.
+            # We use a random IP address from the range specified by the CIDR network notation "89.160.20.112/28"
+            # from https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json
+            # The following value will result in country-code: SE and region-code: E
+            - name: X-Forwarded-For
+              value: '89.160.20.115'
+        response:
+          status_code: 200
+          content:
+            tiles: []

--- a/tools/volumes/client/scenarios_204.yml
+++ b/tools/volumes/client/scenarios_204.yml
@@ -1,0 +1,21 @@
+scenarios:
+  - name: success_204_No_Content_exluded_region
+    description: Test that Contile returns a 204 No Content for excluded regions
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: macos and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 Firefox/91.0'
+            # Contile looks up the IP address from this header value and maps it to proxy information.
+            # We use a random IP address from the range specified by the CIDR network notation "89.160.20.112/28"
+            # from https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json
+            # The following value will result in country-code: SE and region-code: E
+            - name: X-Forwarded-For
+              value: '89.160.20.115'
+        response:
+          status_code: 204
+          content: ''


### PR DESCRIPTION
## Description

This pull request adds two new integration tests for the `excluded_countries_200` functionality of #290.

## Testing

Verify that the two new integration tests run and pass on CI.

## Issue(s)

Resolve #293
