### PR TITLE
Update README with links to docs and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,14 @@
 
 This is the back-end server for the Mozilla Tile Service (MTS).
 
-The goal of this service is to pass tiles from partners along to Firefox for display while ensuring customer privacy and choice.
+The goal of this service is to pass tiles from partners along to Firefox for display while ensuring customer privacy and choice as discussed in the [support article "Sponsored tiles on the New Tab page"](https://support.mozilla.org/en-US/kb/sponsor-privacy).
 
 Supports the TopSites feature within Firefox.
+
+See also:
+
+- [In-repo documentation](docs/)
+- [Monitoring dashboard](https://earthangel-b40313e5.influxcloud.net/d/oak1zw6Gz/contile-infrastructure) (Mozilla internal)
 
 ## Requirements
 


### PR DESCRIPTION
This gives a bit more context for members of the public and also makes it easier for Mozillians not working directly on the project to discover details of the production infrastructure.