### PR TITLE
feat: Refine the host & pathing filter

### DIFF
--- a/adm_settings_test.json
+++ b/adm_settings_test.json
@@ -1,17 +1,26 @@
 {"DEFAULT": {
-    "advertiser_hosts": ["example.com"],
+    "advertiser_urls": [{ "host": "example.com" }],
     "impression_hosts": ["example.net"],
     "click_hosts":["example.com"]
 },
 "Acme": {
-    "advertiser_hosts": ["www.acme.biz", "acme.biz"],
+    "advertiser_urls": [
+        { "host": "www.acme.biz" },
+        { "host": "acme.biz" }
+    ],
     "position": 0
 },
 "Dunder Mifflin": {
-    "advertiser_hosts": ["www.dunderm.biz", "dunderm.biz"],
+    "advertiser_urls": [
+        { "host": "www.dunderm.biz" },
+        { "host": "dunderm.biz" }
+    ],
     "position": 1
 },
 "Los Pollos Hermanos": {
-    "advertiser_hosts": ["www.lph-nm.biz", "lph-mx.co.mx"]
+    "advertiser_urls": [
+        { "host": "www.lph-nm.biz" },
+        { "host": "lph-mx.co.mx" }
+    ]
 }
 }

--- a/integration-tests/volumes/contile/adm_settings.json
+++ b/integration-tests/volumes/contile/adm_settings.json
@@ -1,16 +1,16 @@
 {
     "Example COM": {
-        "advertiser_hosts": [
-            "www.example.com",
-            "www.example.co.uk",
-            "www.example.it",
-            "www.example.com.au",
-            "www.example.ca",
-            "www.example.de",
-            "www.example.fr",
-            "www.example.es",
-            "www.example.in",
-            "www.example.com.mx"
+        "advertiser_urls": [
+            { "host": "www.example.com" },
+            { "host": "www.example.co.uk" },
+            { "host": "www.example.it" },
+            { "host": "www.example.com.au" },
+            { "host": "www.example.ca" },
+            { "host": "www.example.de" },
+            { "host": "www.example.fr" },
+            { "host": "www.example.es" },
+            { "host": "www.example.in" },
+            { "host": "www.example.com.mx" }
         ],
         "click_hosts": [],
         "impression_hosts": [],
@@ -18,8 +18,8 @@
         "position": 1
     },
     "Example ORG": {
-        "advertiser_hosts": [
-            "www.example.org"
+        "advertiser_urls": [
+            { "host": "www.example.org" }
         ],
         "click_hosts": [
             "example.org"
@@ -31,8 +31,8 @@
         "position": 1
     },
     "DunBroch": {
-        "advertiser_hosts": [
-            "www.dunbroch.co.uk"
+        "advertiser_urls": [
+            { "host": "www.dunbroch.co.uk" }
         ],
         "click_hosts": [
             "dunbroch.co.uk"
@@ -46,7 +46,7 @@
         "position": 2
     },
     "DEFAULT": {
-        "advertiser_hosts": [],
+        "advertiser_urls": [],
         "click_hosts": [
             "example.com"
         ],

--- a/src/adm/filter.rs
+++ b/src/adm/filter.rs
@@ -531,13 +531,13 @@ mod tests {
                 {
                     "host": "acme.biz",
                     "paths": [
-                        { "value": "/ca", "matching": "prefix" }
+                        { "value": "/ca/", "matching": "prefix" }
                     ]
                 },
                 {
                     "host": "www.acme.co",
                     "paths": [
-                        { "value": "/foo.bar", "matching": "prefix" }
+                        { "value": "/foo.bar/", "matching": "prefix" }
                     ]
 
                 },

--- a/src/adm/filter.rs
+++ b/src/adm/filter.rs
@@ -115,25 +115,35 @@ impl AdmFilter {
         }
 
         // do a quick string comparison between the supplied host and the provided filter.
-        let mut host = format!(
-            "{}{}",
-            parsed
-                .host()
-                .ok_or_else(|| HandlerErrorKind::MissingHost(species, url.to_string()))?,
-            parsed.path()
-        );
-        if !host.ends_with('/') {
-            host.push('/');
+        let host = parsed
+            .host()
+            .ok_or_else(|| HandlerErrorKind::MissingHost(species, url.to_string()))?
+            .to_string();
+        let mut path = Cow::from(parsed.path());
+        if !path.ends_with('/') {
+            path.to_mut().push('/');
         }
-        for filter in &filter.advertiser_hosts {
-            let mut filter = Cow::from(filter);
-            if !filter.ends_with('/') {
-                filter.to_mut().push('/');
-            };
-            if host.starts_with(filter.as_ref()) {
-                return Ok(());
+
+        for filter in &filter.advertiser_urls {
+            if !host.eq(&filter.host) {
+                continue;
             }
+
+            if let Some(ref paths) = filter.paths {
+                for rule in paths {
+                    match rule.matching.as_str() {
+                        // Note that the orignal path is used for exact matching
+                        "exact" if rule.value == parsed.path() => return Ok(()),
+                        "prefix" if path.starts_with(&rule.value) => return Ok(()),
+                        _ => continue,
+                    }
+                }
+            } else {
+                // Host matches without any path filters, matching succeeds.
+                return Ok(());
+            };
         }
+
         Err(HandlerErrorKind::InvalidHost(species, url.to_string()).into())
     }
 
@@ -294,7 +304,7 @@ impl AdmFilter {
                     return None;
                 }
 
-                let adv_filter = if filter.advertiser_hosts.is_empty() {
+                let adv_filter = if filter.advertiser_urls.is_empty() {
                     default
                 } else {
                     filter
@@ -433,7 +443,27 @@ mod tests {
     #[test]
     fn check_advertiser() {
         let s = r#"{
-            "advertiser_hosts": ["acme.biz/ca", "black_friday.acme.biz/ca"],
+            "advertiser_urls": [
+                {
+                    "host": "acme.biz",
+                    "paths": [
+                        { "value": "/ca/", "matching": "prefix" }
+                    ]
+                },
+                {
+                    "host": "black_friday.acme.biz",
+                    "paths": [
+                        { "value": "/ca/", "matching": "prefix" }
+                    ]
+
+                },
+                {
+                    "host": "acme.biz",
+                    "paths": [
+                        { "value": "/usa", "matching": "exact" }
+                    ]
+                }
+            ],
             "position": 0
         }"#;
         let settings: AdmAdvertiserFilterSettings = serde_json::from_str(s).unwrap();
@@ -477,15 +507,47 @@ mod tests {
             .check_advertiser(&settings, &mut tile, &mut tags)
             .is_err());
 
-        //good, extra element in host
+        //Good, extra element in host
         tile.advertiser_url = "https://black_friday.acme.biz/ca/".to_owned();
         assert!(filter
             .check_advertiser(&settings, &mut tile, &mut tags)
             .is_ok());
 
+        //Good, extra matching
+        tile.advertiser_url = "https://acme.biz/usa".to_owned();
+        assert!(filter
+            .check_advertiser(&settings, &mut tile, &mut tags)
+            .is_ok());
+
+        // Bad, path doesn't match exactly
+        tile.advertiser_url = "https://acme.biz/usa/".to_owned();
+        assert!(filter
+            .check_advertiser(&settings, &mut tile, &mut tags)
+            .is_err());
+
         // "Traditional host. "
         let s = r#"{
-            "advertiser_hosts": ["acme.biz/ca", "www.acme.co/foo.bar"],
+            "advertiser_urls": [
+                {
+                    "host": "acme.biz",
+                    "paths": [
+                        { "value": "/ca", "matching": "prefix" }
+                    ]
+                },
+                {
+                    "host": "www.acme.co",
+                    "paths": [
+                        { "value": "/foo.bar", "matching": "prefix" }
+                    ]
+
+                },
+                {
+                    "host": "acme.biz",
+                    "paths": [
+                        { "value": "/", "matching": "exact" }
+                    ]
+                }
+            ],
             "position": 0
         }"#;
         let settings: AdmAdvertiserFilterSettings = serde_json::from_str(s).unwrap();
@@ -525,5 +587,11 @@ mod tests {
         assert!(filter
             .check_advertiser(&settings, &mut tile, &mut tags)
             .is_err());
+
+        //Good, matches exact host and path
+        tile.advertiser_url = "https://acme.biz/".to_owned();
+        assert!(filter
+            .check_advertiser(&settings, &mut tile, &mut tags)
+            .is_ok());
     }
 }

--- a/src/adm/settings.rs
+++ b/src/adm/settings.rs
@@ -28,8 +28,8 @@ pub(crate) const DEFAULT: &str = "DEFAULT";
 ///         "host": "foo.com",
 ///         "paths": [
 ///             { "value": "/", "matching": "exact" },
-///             { "value": "/bar", "matching": "prefix" },
-///             { "value": "/baz/spam", "matching": "prefix" },
+///             { "value": "/bar/", "matching": "prefix" },
+///             { "value": "/baz/spam/", "matching": "prefix" },
 ///         ]
 ///     }
 /// ```
@@ -47,7 +47,8 @@ pub(crate) const DEFAULT: &str = "DEFAULT";
 ///   * "prefix" for prefix path matching, which checks if the `value` is a
 ///     prefix of the `path`. Note that we always make sure `path` and `value`
 ///     are compared with the trailing '/' to avoid the accidental
-///     matches.
+///     matches. In particular, Contile will panic when it detects that a prefix
+///     filter doesn't have the trailing '/' in the `value`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AdvertiserUrlFilter {
     pub(crate) host: String,

--- a/src/adm/settings.rs
+++ b/src/adm/settings.rs
@@ -36,19 +36,23 @@ pub(crate) const DEFAULT: &str = "DEFAULT";
 /// For each `advertiser_url` (assume its host is `host` and path is `path`),
 /// the matching rule is defined as follows:
 ///
-/// * Check if `host` matches with `filter.host`. If not, this URL is rejected
-///   by this filter.
-/// * If the host matches, and there is no `paths` specified in this filter,
+/// * Check if the host in the advertiser URL exactly matches with the `"host"`
+///   value in this filter.  If not, this URL is rejected by this filter.
+///   For example `https://foo.com` would match, however `https://www.foo.com`
+///   would *not* match and would be rejected. If you wish to include both
+///   hosts, you will need to duplicate the `"paths"`.
+/// * If the host matches, and there is no `"paths"` specified in this filter,
 ///   then the URL is accepted by this filter.
-/// * If the `paths` filter list is present, then proceed with path filtering.
-///   There are two "matching" strategies:
-///   * "exact" for exact path matching, which compares the `path` character-by-character
-///     with the `value` filed of this path filter.
+/// * If the `"paths"` filter list is present, then proceed with path filtering.
+///   There are two matching strategies:
+///   * `"exact"` for exact path matching, which compares the `"path"`
+///     character-by-character with the `"value"` filed of this path filter.
 ///   * "prefix" for prefix path matching, which checks if the `value` is a
-///     prefix of the `path`. Note that we always make sure `path` and `value`
+///     prefix of the `"path"`. Note that we always make sure `"path"` and `"value"`
 ///     are compared with the trailing '/' to avoid the accidental
-///     matches. In particular, Contile will panic when it detects that a prefix
-///     filter doesn't have the trailing '/' in the `value`.
+///     matches. In particular, when loading filters from the settings file,
+///     Contile will panic if it detects that a prefix filter doesn't have
+///     the trailing '/' in the `"value"`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AdvertiserUrlFilter {
     pub(crate) host: String,
@@ -337,7 +341,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "Advertiser \"test-adv\" advertiser_urls contain invalid prefix PathFilter"
+        expected = r#"Advertiser "test-adv" advertiser_urls contain invalid prefix PathFilter"#
     )]
     pub fn test_invalid_path_filters() {
         let mut settings = Settings::default();

--- a/src/adm/settings.rs
+++ b/src/adm/settings.rs
@@ -17,6 +17,51 @@ use crate::{
 /// is defined for a given partner.
 pub(crate) const DEFAULT: &str = "DEFAULT";
 
+/// The AdvertiserUrlFilter describes the filtering rule for the `advertiser_url`.
+///
+/// Each rule consists of a host and optionally a list of PathFilters.
+///
+/// Examples:
+///
+/// ```json
+///     {
+///         "host": "foo.com",
+///         "paths": [
+///             { "value": "/", "matching": "exact" },
+///             { "value": "/bar", "matching": "prefix" },
+///             { "value": "/baz/spam", "matching": "prefix" },
+///         ]
+///     }
+/// ```
+/// For each `advertiser_url` (assume its host is `host` and path is `path`),
+/// the matching rule is defined as follows:
+///
+/// * Check if `host` matches with `filter.host`. If not, this URL is rejected
+///   by this filter.
+/// * If the host matches, and there is no `paths` specified in this filter,
+///   then the URL is accepted by this filter.
+/// * If the `paths` filter list is present, then proceed with path filtering.
+///   There are two "matching" strategies:
+///   * "exact" for exact path matching, which compares the `path` character-by-character
+///     with the `value` filed of this path filter.
+///   * "prefix" for prefix path matching, which checks if the `value` is a
+///     prefix of the `path`. Note that we always make sure `path` and `value`
+///     are compared with the trailing '/' to avoid the accidental
+///     matches.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AdvertiserUrlFilter {
+    pub(crate) host: String,
+    pub(crate) paths: Option<Vec<PathFilter>>,
+}
+
+/// PathFilter describes how path filtering is conducted. See more details in
+/// AdvertiserUrlFilter.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PathFilter {
+    pub(crate) value: String,
+    pub(crate) matching: String,
+}
+
 /// The AdmAdvertiserFilterSettings contain the settings for the various
 /// ADM provided partners.
 ///
@@ -27,9 +72,9 @@ pub(crate) const DEFAULT: &str = "DEFAULT";
 /// defined in DEFAULT.
 #[derive(Clone, Debug, Deserialize, Default, Serialize)]
 pub struct AdmAdvertiserFilterSettings {
-    /// Required set of valid hosts for the `advertiser_url`
-    #[serde(deserialize_with = "deserialize_advertiser", default)]
-    pub(crate) advertiser_hosts: Vec<String>,
+    /// Required set of valid hosts and paths for the `advertiser_url`
+    #[serde(default)]
+    pub(crate) advertiser_urls: Vec<AdvertiserUrlFilter>,
     /// Optional set of valid hosts for the `impression_url`
     #[serde(
         deserialize_with = "deserialize_hosts",
@@ -52,33 +97,6 @@ pub struct AdmAdvertiserFilterSettings {
     pub(crate) include_regions: Vec<String>,
     pub(crate) ignore_advertisers: Option<Vec<String>>,
     pub(crate) ignore_dmas: Option<Vec<u8>>,
-}
-
-/// Parse JSON:
-/// fail if you encounter a host that does not match the pattern.
-/// (if only specifying hosts, use "example.com", if requiring a leading path
-///  use "example.com/path/")
-fn deserialize_advertiser<'de, D>(d: D) -> Result<Vec<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Deserialize::deserialize(d).map(|hosts: Vec<String>| {
-        for host in &hosts {
-            if host.contains('/') {
-                let parts: Vec<&str> = host.splitn(2, '/').collect();
-                assert!(!parts[1].is_empty(), "Advertiser host path is empty.")
-            } else {
-                for cmp_host in &hosts {
-                    if !cmp_host.contains('/') {
-                        continue;
-                    }
-                    let parts: Vec<&str> = cmp_host.splitn(2, '/').collect();
-                    assert!(parts[0] != host, "Advertiser host conflict.")
-                }
-            }
-        }
-        hosts
-    })
 }
 
 /// Parse JSON:
@@ -166,6 +184,16 @@ impl From<&mut Settings> for AdmSettings {
             {
                 panic!("Advertiser {:?} include_regions must be uppercase", adv);
             }
+            if filter_setting.advertiser_urls.iter().any(|filter| {
+                if let Some(ref paths) = filter.paths {
+                    return paths
+                        .iter()
+                        .any(|path| path.matching == "prefix" && !path.value.ends_with('/'));
+                }
+                false
+            }) {
+                panic!("Advertiser {:?} advertiser_urls contain invalid prefix PathFilter (missing trailing '/')", adv);
+            }
         }
         adm_settings
     }
@@ -178,7 +206,7 @@ impl From<&mut Settings> for AdmSettings {
 /// /* for the Example Co advertiser... */
 /// {"Example": {
 ///     /* The allowed hosts for URLs */
-///     "advertiser_hosts": ["www.example.org", "example.org"],
+///     "advertiser_urls": [{"host": "www.example.org"}, {"host": "example.org"}],
 ///     /* Valid tile positions for this advertiser (empty for "all") */
 ///     "positions": 1,
 ///     /* Valid target countries for this advertiser
@@ -307,55 +335,25 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    pub fn mismatched_advertisers() {
-        let _val = serde_json::from_str::<AdmAdvertiserFilterSettings>(
-            r#"
-        {"advertiser_hosts": ["foo.bar", "foo.bar/ca"],
-        }
-        "#,
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    pub fn conflicting_advertiser_paths() {
-        let _val = serde_json::from_str::<AdmAdvertiserFilterSettings>(
-            r#"
-        {"advertiser_hosts": ["foo.bar/ca", "foo.bar"],
-        }
-        "#,
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    pub fn empty_advertiser_paths() {
-        let _val = serde_json::from_str::<AdmAdvertiserFilterSettings>(
-            r#"
-        {"advertiser_hosts": ["foo.bar/ca", "foo.biz/"],
-        }
-        "#,
-        );
-    }
-
-    #[test]
-    pub fn ok_advertiser_paths() {
-        let _val = serde_json::from_str::<AdmAdvertiserFilterSettings>(
-            r#"
-        {"advertiser_hosts": ["foo.bar/ca", "foo.bar/us"],
-        }
-        "#,
-        );
-    }
-
-    #[test]
-    pub fn ok_advertisers() {
-        let _val = serde_json::from_str::<AdmAdvertiserFilterSettings>(
-            r#"{"advertiser_hosts": ["foo.com/ca", "foo.co.uk", "www.foo.co.uk"]}"#,
-        );
-        let _val = serde_json::from_str::<AdmAdvertiserFilterSettings>(
-            r#"{"advertiser_hosts": ["example.com", "example.com.mx"]}"#,
-        );
+    #[should_panic(
+        expected = "Advertiser \"test-adv\" advertiser_urls contain invalid prefix PathFilter"
+    )]
+    pub fn test_invalid_path_filters() {
+        let mut settings = Settings::default();
+        let adm_settings = r#"{"test-adv": {
+            "advertiser_urls": [
+                {
+                    "host": "foo.com",
+                    "paths": [
+                        {
+                            "value": "/bar",
+                            "matching": "prefix"
+                        }
+                    ]
+                }
+            ]
+        }}"#;
+        settings.adm_settings = adm_settings.to_owned();
+        AdmSettings::from(&mut settings);
     }
 }

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -126,28 +126,28 @@ fn init_mock_adm(response: String) -> MockAdm {
 pub fn adm_settings() -> AdmSettings {
     let adm_settings = json!({
         "Acme": {
-            "advertiser_hosts": ["www.acme.biz"],
+            "advertiser_urls": [{ "host": "www.acme.biz" }],
             "impression_hosts": [],
             "click_hosts": [],
             "position": 0,
             "include_regions": ["US"]
         },
         "Dunder Mifflin": {
-            "advertiser_hosts": ["www.dunderm.biz"],
+            "advertiser_urls": [{ "host": "www.dunderm.biz" }],
             "impression_hosts": ["example.com", "example.net"],
             "click_hosts": [],
             "position": 1,
             "include_regions": ["US"]
         },
         "Los Pollos Hermanos": {
-            "advertiser_hosts": ["www.lph-nm.biz"],
+            "advertiser_urls": [{ "host": "www.lph-nm.biz" }],
             "impression_hosts": [],
             "click_hosts": [],
             "position": 2,
             "include_regions": ["US"]
         },
         DEFAULT: {
-            "advertiser_hosts": [],
+            "advertiser_urls": [],
             "impression_hosts": ["example.net"],
             "click_hosts": ["example.com"],
             "position": null,
@@ -339,7 +339,7 @@ async fn basic_filtered() {
     adm_settings.insert(
         "Example".to_owned(),
         serde_json::from_value(json!({
-            "advertiser_hosts": ["www.example.ninja"],
+            "advertiser_urls": [{ "host": "www.example.ninja" }],
             "impression_hosts": ["example.net"],
             "click_hosts": ["example.com"],
             "position": 100,
@@ -503,7 +503,7 @@ async fn empty_tiles() {
     // test empty responses of an included country (US)
     let adm_settings_json = json!({
         "Foo": {
-            "advertiser_hosts": ["www.foo.bar"],
+            "advertiser_urls": [{ "host": "www.foo.bar" }],
             "impression_hosts": [],
             "click_hosts": [],
             "position": 0,


### PR DESCRIPTION
After a second thought, I don't think letting the content partner send whatever URLs to us is a good idea, so I took a crack at refining the existing pathing filter with the following changes:
* Rename the `advertiser_hosts` to `advertiser_urls`
* `advertiser_urls` now takes a list of hosts and path filters (optional). If no path filter is specified, it will only check the host as the current behavior
* Each path filter could be either an "exact-matching" filter or a "prefix-matching" one
* The "value" field for "prefix-matching" filters must contain the trailing "/" in the configuration, otherwise, Contile will panic

The detail of the filtering is documented [here](https://github.com/mozilla-services/contile/pull/311/files#diff-34387244eabf61c959f3a7e535ca04a551c779b9ee645d2e93303c0020f5a881).

Note: this is a breaking change, we'd need to update the Contile configuration file if we want to deploy this.

@hackebrot could you also take a look at the change in the integration test? I am not sure if I covered everything there. Thanks!