### PR TITLE
Integration test coverage for path filtering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,13 +214,30 @@ jobs:
             -f integration-tests/docker-compose.yml \
             up --abort-on-container-exit --force-recreate
       - run:
-         name: Run additional integration tests
+         name: 'Run "204" integration tests'
          command: |
            docker-compose --version
            docker-compose \
             -f integration-tests/docker-compose.yml \
             -f integration-tests/docker-compose.204.yml \
             up --abort-on-container-exit --force-recreate
+      - run:
+         name: 'Run "init_error" integration tests'
+         command: |
+           docker-compose --version
+           set +e # We need this so that the run doesn't exit after docker-compose
+           docker-compose \
+            -f integration-tests/docker-compose.yml \
+            -f integration-tests/docker-compose.init_error.yml \
+            up --abort-on-container-exit --exit-code contile --force-recreate
+           contile_exit_code=$?
+           if [ "${contile_exit_code}" -eq 0 ]; then
+            echo "Expected non-zero exit_code from Contile service"
+            exit 1
+           else
+            echo "Contile service exit_code: ${contile_exit_code}"
+            exit 0
+           fi
 
 workflows:
   version: 2

--- a/integration-tests/docker-compose.init_error.yml
+++ b/integration-tests/docker-compose.init_error.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+  contile:
+    environment:
+      CONTILE_ADM_SETTINGS: /tmp/contile/adm_settings_init_error.json
+  client:
+    environment:
+      SCENARIOS_FILE: /tmp/client/scenarios_init_error.yml

--- a/integration-tests/volumes/client/scenarios.yml
+++ b/integration-tests/volumes/client/scenarios.yml
@@ -316,3 +316,88 @@ scenarios:
           status_code: 200
           content:
             tiles: []
+
+  - name: advertiser_url_path_filter_prefix
+    description: >
+      Test that Contile successfully applies advertiser_url path filters with
+      prefix matching. The request is expected to not result in any DunBroch
+      tiles because the settings do not allow URL paths with a
+      `gb_desktop_windows` prefix for DunBroch tiles.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: windows and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            # Contile looks up the IP address from this header value and maps it to proxy information.
+            # We use a random IP address from the range specified by the CIDR network notation "81.2.69.192/28"
+            # from https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json
+            # The following value will result in country-code: GB and region-code: ENG
+            - name: X-Forwarded-For
+              value: '81.2.69.204'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 32345
+                name: 'Example COM'
+                click_url: 'https://example.com/gb_desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/gb_desktop_windows01.jpg'
+                image_size: null
+                impression_url: 'https://example.com/gb_desktop_windows?id=0001'
+                url: 'https://www.example.com/gb_desktop_windows'
+                position: 1
+              - id: 76789
+                name: 'Example ORG'
+                click_url: 'https://example.org/gb_desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/gb_desktop_windows02.jpg'
+                image_size: null
+                impression_url: 'https://example.org/gb_desktop_windows?id=0002'
+                url: 'https://www.example.org/gb_desktop_windows'
+                position: 1
+
+  - name: advertiser_url_path_filter_exact
+    description: >
+      Test that Contile successfully applies advertiser_url path filters with
+      exact matching. The request is expected to not result in any DunBroch
+      tiles because the settings only allow exact `gb_desktop_linux` paths, but
+      the DunBroch tile for the proxy parameters in the step has a URL path of
+      `gb_desktop_linux/2021` and the additional path segment is not approved.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: linux and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (X11; Linux x86_64; rv:90.0) Gecko/20100101 Firefox/91.0'
+            # Contile looks up the IP address from this header value and maps it to proxy information.
+            # We use a random IP address from the range specified by the CIDR network notation "81.2.69.192/28"
+            # from https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json
+            # The following value will result in country-code: GB and region-code: ENG
+            - name: X-Forwarded-For
+              value: '81.2.69.204'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 32347
+                name: 'Example COM'
+                click_url: 'https://example.com/gb_desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/gb_desktop_linux01.jpg'
+                image_size: null
+                impression_url: 'https://example.com/gb_desktop_linux?id=0001'
+                url: 'https://www.example.com/gb_desktop_linux'
+                position: 1
+              - id: 76791
+                name: 'Example ORG'
+                click_url: 'https://example.org/gb_desktop_linux?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/gb_desktop_linux02.jpg'
+                image_size: null
+                impression_url: 'https://example.org/gb_desktop_linux?id=0002'
+                url: 'https://www.example.org/gb_desktop_linux'
+                position: 1

--- a/integration-tests/volumes/client/scenarios_init_error.yml
+++ b/integration-tests/volumes/client/scenarios_init_error.yml
@@ -1,0 +1,33 @@
+scenarios:
+  - name: advertiser_url_prefix_path_filter_missing_slash
+    description: >
+      Test that Contile terminates with an error if the adm_settings.json file
+      contains a prefix path value without a trailing slash character.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: windows and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            # Contile looks up the IP address from this header value and maps it to proxy information.
+            # We use a random IP address from the range specified by the CIDR network notation "81.2.69.192/28"
+            # from https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json
+            # The following value will result in country-code: GB and region-code: ENG
+            - name: X-Forwarded-For
+              value: '81.2.69.204'
+        response:
+          # We expect this to fail, because Contile should terminate when loading the settings
+          status_code: 200
+          content:
+            tiles:
+              - id: 41234
+                name: 'DunBroch'
+                click_url: 'https://dunbroch.co.uk/gb_desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://dunbroch.co.uk/gb_desktop_windows01.jpg'
+                image_size: null
+                impression_url: 'https://dunbroch.co.uk/gb_desktop_windows?id=0001'
+                url: 'https://www.dunbroch.co.uk/gb_desktop_windows'
+                position: 2

--- a/integration-tests/volumes/contile/adm_settings.json
+++ b/integration-tests/volumes/contile/adm_settings.json
@@ -1,16 +1,36 @@
 {
     "Example COM": {
         "advertiser_urls": [
-            { "host": "www.example.com" },
-            { "host": "www.example.co.uk" },
-            { "host": "www.example.it" },
-            { "host": "www.example.com.au" },
-            { "host": "www.example.ca" },
-            { "host": "www.example.de" },
-            { "host": "www.example.fr" },
-            { "host": "www.example.es" },
-            { "host": "www.example.in" },
-            { "host": "www.example.com.mx" }
+            {
+                "host": "www.example.com"
+            },
+            {
+                "host": "www.example.co.uk"
+            },
+            {
+                "host": "www.example.it"
+            },
+            {
+                "host": "www.example.com.au"
+            },
+            {
+                "host": "www.example.ca"
+            },
+            {
+                "host": "www.example.de"
+            },
+            {
+                "host": "www.example.fr"
+            },
+            {
+                "host": "www.example.es"
+            },
+            {
+                "host": "www.example.in"
+            },
+            {
+                "host": "www.example.com.mx"
+            }
         ],
         "click_hosts": [],
         "impression_hosts": [],
@@ -19,7 +39,9 @@
     },
     "Example ORG": {
         "advertiser_urls": [
-            { "host": "www.example.org" }
+            {
+                "host": "www.example.org"
+            }
         ],
         "click_hosts": [
             "example.org"
@@ -32,7 +54,9 @@
     },
     "DunBroch": {
         "advertiser_urls": [
-            { "host": "www.dunbroch.co.uk" }
+            {
+                "host": "www.dunbroch.co.uk"
+            }
         ],
         "click_hosts": [
             "dunbroch.co.uk"

--- a/integration-tests/volumes/contile/adm_settings.json
+++ b/integration-tests/volumes/contile/adm_settings.json
@@ -55,7 +55,17 @@
     "DunBroch": {
         "advertiser_urls": [
             {
-                "host": "www.dunbroch.co.uk"
+                "host": "www.dunbroch.co.uk",
+                "paths": [
+                    {
+                        "value": "/gb_desktop_macos/",
+                        "matching": "prefix"
+                    },
+                    {
+                        "value": "/gb_desktop_linux",
+                        "matching": "exact"
+                    }
+                ]
             }
         ],
         "click_hosts": [

--- a/integration-tests/volumes/contile/adm_settings_init_error.json
+++ b/integration-tests/volumes/contile/adm_settings_init_error.json
@@ -1,0 +1,38 @@
+{
+    "DunBroch": {
+        "advertiser_urls": [
+            {
+                "host": "www.dunbroch.co.uk",
+                "paths": [
+                    {
+                        "value": "/gb_desktop",
+                        "matching": "prefix"
+                    }
+                ]
+            }
+        ],
+        "click_hosts": [
+            "dunbroch.co.uk"
+        ],
+        "impression_hosts": [
+            "dunbroch.co.uk"
+        ],
+        "include_regions": [
+            "GB"
+        ],
+        "position": 2
+    },
+    "DEFAULT": {
+        "advertiser_urls": [],
+        "click_hosts": [
+            "example.com"
+        ],
+        "impression_hosts": [
+            "example.com"
+        ],
+        "include_regions": [
+            "US",
+            "GB"
+        ]
+    }
+}

--- a/integration-tests/volumes/partner/GB/responses.yml
+++ b/integration-tests/volumes/partner/GB/responses.yml
@@ -59,7 +59,7 @@ desktop:
             click_url: 'https://dunbroch.co.uk/gb_desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
             image_url: 'https://dunbroch.co.uk/gb_desktop_linux01.jpg'
             impression_url: 'https://dunbroch.co.uk/gb_desktop_linux?id=0001'
-            advertiser_url: 'https://www.dunbroch.co.uk/gb_desktop_linux'
+            advertiser_url: 'https://www.dunbroch.co.uk/gb_desktop_linux/2021'
           - id: 32347
             name: 'Example COM'
             click_url: 'https://example.com/gb_desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'


### PR DESCRIPTION
## Description

This pull request is a follow-up for #311 and uses that branch as a base. I will rebase this once #311 is merged.

Please see the test scenario descriptions in `integration-tests/volumes/client/scenarios.yml` and let me know if you have any questions about the scenarios.

Note that I've observed unexpected behavior when working this, which I described in https://github.com/mozilla-services/contile/pull/311#issuecomment-961752700. 🚧 

## Testing

Verify that the following 2 new integration tests run and pass on CI:

* `advertiser_url_path_filter_prefix`
* `advertiser_url_path_filter_exact`

## Issue(s)

See #311 