### PR TITLE
feat: only include hostname in InvalidHost's err message

### DIFF
--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -170,6 +170,7 @@ pub async fn get_tiles(
             .into_string()
             .unwrap_or_else(|_| "Unknown".to_owned()),
     );
+    tags.add_extra("adm_url", adm_url);
 
     info!("adm::get_tiles GET {}", adm_url);
     metrics.incr("tiles.adm.request");

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -67,14 +67,6 @@ pub async fn get_tiles(
         return Ok(response);
     }
 
-    let mut tags = Tags::default();
-    {
-        tags.add_extra("country", &location.country());
-        tags.add_extra("region", &location.region());
-        // Add/modify the existing request tags.
-        // tags.clone().commit(&mut request.extensions_mut());
-    }
-
     let audience_key = cache::AudienceKey {
         country_code: location.country(),
         region_code: if location.region() != "" {
@@ -87,6 +79,13 @@ pub async fn get_tiles(
         os_family: device_info.os_family,
         legacy_only: device_info.legacy_only(),
     };
+
+    let mut tags = Tags::default();
+    {
+        tags.add_extra("audience_key", &format!("{:#?}", audience_key));
+        // Add/modify the existing request tags.
+        // tags.clone().commit(&mut request.extensions_mut());
+    }
 
     let mut expired = false;
     if !settings.test_mode {


### PR DESCRIPTION
to reduce the sentry event cardinality from paths/their query parameters

also include the full audience key & adm_url as extras

Closes #322
Closes #323