### PR TITLE
bug: fix YAML schema warning for CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,14 +127,14 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-          = run:
-            name: Login to Dockerhub
-            command: |
-              if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
-                echo "Skipping Login to DockerHub, credentials unavailable"
-              else
-                echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
-              fi
+      - run:
+          name: Login to Dockerhub
+          command: |
+            if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
+              echo "Skipping Login to DockerHub, credentials unavailable"
+            else
+              echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
+            fi
       #- save-sccache-cache
       - checkout
       - write-version


### PR DESCRIPTION
## Description

This pull request fixes the YAML schema warning for the CircleCI config.

It replaces `=` with `-` and fixes the indentation for the `run` step.

@pjenvey, I believe this job was generated from the skeleton. Do we want to login to DockerHub as part of this job?

## Testing

Verify that the `Login to Dockerhub` step runs for the `build` job on CI.

## Issue(s)

Resolve #328
