### PR TITLE
Upgrade contile-integration-tests Docker images 🤖

### DIFF
--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - partner
     environment:
       CONTILE_MAXMINDDB_LOC: /tmp/mmdb/GeoLite2-City-Test.mmdb
-      CONTILE_ADM_ENDPOINT_URL: http://partner:5000/tilesp
+      CONTILE_ADM_ENDPOINT_URL: http://partner:5000/tilesp/desktop
       CONTILE_ADM_QUERY_TILE_COUNT: 5
       CONTILE_ADM_SETTINGS: /tmp/contile/adm_settings.json
       CONTILE_ADM_HAS_LEGACY_IMAGE: '["Example ORG","Example COM"]'

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       PORT: 5000
       RESPONSES_DIR: /tmp/partner/
+      ACCEPTED_MOBILE_FORM_FACTORS: 'desktop,phone,tablet'
+      ACCEPTED_DESKTOP_FORM_FACTORS: 'desktop,phone,tablet'
     expose:
       - "5000"
     volumes:

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   partner:
-    image: mozilla/contile-integration-tests-partner:21.6.0
+    image: mozilla/contile-integration-tests-partner:22.1.0
     container_name: partner
     environment:
       PORT: 5000
@@ -47,7 +47,7 @@ services:
     #entrypoint: >
     #  /bin/sh -c "hostname -I && bin/contile"
   client:
-    image: mozilla/contile-integration-tests-client:21.6.0
+    image: mozilla/contile-integration-tests-client:22.1.0
     container_name: client
     depends_on:
       - partner


### PR DESCRIPTION
See https://github.com/mozilla-services/contile-integration-tests/releases/tag/22.1.0

- test: upgrade the Docker images for contile-integration-tests to 22.1.0
- test: add accepted form-factors for partner API endpoints
