### PR TITLE
feat: Return JSON error messages

### DIFF
--- a/integration-tests/volumes/client/scenarios.yml
+++ b/integration-tests/volumes/client/scenarios.yml
@@ -168,7 +168,9 @@ scenarios:
               value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/35.0 Mobile/15E148 Safari/605.1.15'
         response:
           status_code: 503 # Service Unavailable
-          content: 522
+          content:
+            errno: 522
+            error: 'An invalid response received from the partner'
 
   - name: error_invalid_user_agent
     description: Test that Contile correctly handles requests from non Firefox clients.
@@ -183,7 +185,9 @@ scenarios:
               value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15'
         response:
           status_code: 403 # Forbidden
-          content: 700
+          content:
+            errno: 700
+            error: 'This service is for firefox only'
 
   - name: success_country_code_region_code
     description: Test that Contile successfully returns tiles for a specific country and region.

--- a/integration-tests/volumes/client/scenarios.yml
+++ b/integration-tests/volumes/client/scenarios.yml
@@ -136,7 +136,9 @@ scenarios:
               value: 'Mozilla/5.0 (Android 11; Mobile; rv:92.0) Gecko/92.0 Firefox/92.0'
         response:
           status_code: 500 # Internal Server Error
-          content: 520
+          content:
+            errno: 520
+            error: 'An error occurred while trying to request data'
 
   - name: error_tablet_ios_reqwest_error
     description: Test that Contile correctly handles invalid tiles responses from the partner API.

--- a/integration-tests/volumes/client/scenarios.yml
+++ b/integration-tests/volumes/client/scenarios.yml
@@ -137,6 +137,7 @@ scenarios:
         response:
           status_code: 500 # Internal Server Error
           content:
+            code: 500
             errno: 520
             error: 'An error occurred while trying to request data'
 
@@ -169,6 +170,7 @@ scenarios:
         response:
           status_code: 503 # Service Unavailable
           content:
+            code: 503
             errno: 522
             error: 'An invalid response received from the partner'
 
@@ -186,6 +188,7 @@ scenarios:
         response:
           status_code: 403 # Forbidden
           content:
+            code: 403
             errno: 700
             error: 'This service is for firefox only'
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -149,7 +149,7 @@ impl HandlerErrorKind {
         match self {
             HandlerErrorKind::General(_) | HandlerErrorKind::Internal(_) => self.to_string(),
             HandlerErrorKind::Reqwest(_) => {
-                format!("An error occurred while trying to request data")
+                "An error occurred while trying to request data".to_string()
             }
             HandlerErrorKind::BadAdmResponse(_)
             | HandlerErrorKind::AdmServerError()
@@ -160,11 +160,11 @@ impl HandlerErrorKind {
             | HandlerErrorKind::MissingHost(_, _)
             | HandlerErrorKind::UnexpectedAdvertiser(_)
             | HandlerErrorKind::BadImage(_) => {
-                format!("An invalid response received from the partner")
+                "An invalid response received from the partner".to_string()
             }
             HandlerErrorKind::Location(_) => self.to_string(),
-            HandlerErrorKind::CloudStorage(_) => format!("Could not cache an tile image"),
-            HandlerErrorKind::InvalidUA => format!("This service is for firefox only"),
+            HandlerErrorKind::CloudStorage(_) => "Could not cache an tile image".to_string(),
+            HandlerErrorKind::InvalidUA => "This service is for firefox only".to_string(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -238,6 +238,7 @@ impl ResponseError for HandlerError {
     fn error_response(&self) -> HttpResponse {
         let mut resp = HttpResponse::build(self.status_code());
         resp.json(json!({
+            "code": self.kind().http_status().as_u16(),
             "errno": self.kind().errno(),
             "error": self.kind().as_response_string(),
         }))


### PR DESCRIPTION
Return more useful JSON error messages.
NOTE: We may not want to use the string versions of all errors we're
sending to sentry, so a "simplified" error message is generated.

Closes #177