### PR TITLE
feat: include os-family and form-factor as metric tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -175,9 +175,12 @@ pub async fn get_tiles(
             .into_string()
             .unwrap_or_else(|_| "Unknown".to_owned()),
     );
+    if device_info.is_mobile() {
+        tags.add_tag("endpoint", "mobile");
+    }
     tags.add_extra("adm_url", adm_url);
 
-    metrics.incr("tiles.adm.request");
+    metrics.incr_with_tags("tiles.adm.request", Some(tags));
     let response: AdmTileResponse = match state.settings.test_mode {
         crate::settings::TestModes::TestFakeResponse => {
             let default = HeaderValue::from_str(DEFAULT).unwrap();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -255,9 +255,8 @@ mod tests {
 
         let tags = Tags::from_head(&rh, &settings);
 
-        assert_eq!(tags.tags.get("ua.os.ver"), Some(&"NT 10.0".to_owned()));
-        assert_eq!(tags.tags.get("ua.os.family"), Some(&"Windows".to_owned()));
-        assert_eq!(tags.tags.get("ua.browser.ver"), Some(&"72.0".to_owned()));
+        assert_eq!(tags.tags.get("ua.os.family"), Some(&"windows".to_owned()));
+        assert_eq!(tags.tags.get("ua.form_factor"), Some(&"desktop".to_owned()));
         assert_eq!(tags.tags.get("uri.method"), Some(&"GET".to_owned()));
     }
 

--- a/src/server/img_storage.rs
+++ b/src/server/img_storage.rs
@@ -646,8 +646,7 @@ mod tests {
         img_store.store(&target).await.expect("Store failed");
         assert_eq!(rx.len(), 4);
         let spied_metrics: Vec<String> = rx
-            .iter()
-            .take(4)
+            .try_iter()
             .map(|x| String::from_utf8(x).unwrap())
             .collect();
         assert_eq!(

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -5,8 +5,7 @@
 
 use actix_web::{
     dev::Payload,
-    http::header,
-    http::{HeaderName, HeaderValue},
+    http::{header, HeaderValue},
     Error, FromRequest, HttpRequest,
 };
 use futures::future::{self, FutureExt, LocalBoxFuture};
@@ -19,7 +18,6 @@ use crate::{
 
 lazy_static! {
     static ref EMPTY_HEADER: HeaderValue = HeaderValue::from_static("");
-    static ref X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
 }
 
 impl FromRequest for DeviceInfo {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -8,4 +8,4 @@ pub(crate) mod test;
 mod user_agent;
 
 pub use dockerflow::DOCKER_FLOW_ENDPOINTS;
-pub use user_agent::{DeviceInfo, FormFactor, OsFamily};
+pub use user_agent::{get_device_info, DeviceInfo, FormFactor, OsFamily};


### PR DESCRIPTION
and kill other unused UA metric tags which have too high of cardinality anyway

also tag mobile endpoint requests

Closes #369