### PR TITLE
chore: prefer CIRCLE_SHA1 vs CIRCLE_TAG in circle's cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,12 @@ commands:
     steps:
       - restore_cache:
           name: Restore sccache cache
-          key: sccache-cache-stable-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}
+          key: sccache-cache-stable-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
   save-sccache-cache:
     steps:
       - save_cache:
           name: Save sccache cache
-          key: sccache-cache-stable-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}-{{ epoch }}
+          key: sccache-cache-stable-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - "~/.cache/sccache"
 jobs:
@@ -149,7 +149,7 @@ jobs:
             mkdir -p /home/circleci/cache
             docker save -o /home/circleci/cache/docker.tar "app:build"
       - save_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}-{{ epoch }}
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}-{{ epoch }}
           paths:
             - /home/circleci/cache
 
@@ -162,7 +162,7 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Restore Docker image cache
           command: docker load -i /home/circleci/cache/docker.tar
@@ -198,7 +198,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_TAG }}
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
          name: Restore Docker image cache
          command: docker load -i /home/circleci/cache/docker.tar

--- a/src/adm/filter.rs
+++ b/src/adm/filter.rs
@@ -280,7 +280,7 @@ impl AdmFilter {
 
         // run the gauntlet of checks.
         if !check_url(parsed, "Click", &filter.click_hosts)? {
-            trace!("bad url: url={:?}", url.to_string());
+            trace!("bad url: url={:?}", url);
             tags.add_tag("type", species);
             tags.add_extra("tile", &tile.name);
             tags.add_extra("url", url);
@@ -290,7 +290,7 @@ impl AdmFilter {
         }
         for key in &*REQ_CLICK_PARAMS {
             if !query_keys.contains(*key) {
-                trace!("missing param: key={:?} url={:?}", &key, url.to_string());
+                trace!("missing param: key={:?} url={:?}", &key, url);
                 tags.add_tag("type", species);
                 tags.add_extra("tile", &tile.name);
                 tags.add_extra("url", url);
@@ -302,7 +302,7 @@ impl AdmFilter {
         }
         for key in query_keys {
             if !ALL_CLICK_PARAMS.contains(key.as_str()) {
-                trace!("invalid param key={:?} url={:?}", &key, url.to_string());
+                trace!("invalid param key={:?} url={:?}", &key, url);
                 tags.add_tag("type", species);
                 tags.add_extra("tile", &tile.name);
                 tags.add_extra("url", url);
@@ -333,7 +333,7 @@ impl AdmFilter {
             .collect::<Vec<String>>();
         query_keys.sort();
         if query_keys != vec!["id"] {
-            trace!("missing param key=id url={:?}", url.to_string());
+            trace!("missing param key=id url={:?}", url);
             tags.add_tag("type", species);
             tags.add_extra("tile", &tile.name);
             tags.add_extra("url", url);


### PR DESCRIPTION
per https://github.com/mozilla-services/Dockerflow/pull/44

_TAG seems to only fix this issue on tagged builds, whereas _SHA1 should also
solve it on dev builds lacking a tag

and switch the currently unused sccache key to CIRCLE_JOB

Closes #380