### PR TITLE
fix: Add get_id_token function and Authorization header

### DIFF
--- a/smoke-tests/runner/requirements.txt
+++ b/smoke-tests/runner/requirements.txt
@@ -14,3 +14,4 @@ Werkzeug==1.0.1
 
 # Custom packages
 requests==2.26.0
+google-auth==2.6.2


### PR DESCRIPTION
Client cloud functions are configured to require a valid ID token
associated with a service account that has the invoke permission.
This change adds a method to request an ID token and adds it as
a header to the request invoking the client functions.