### PR TITLE
refactor: Use async friendly RwLocks in async code paths

### DIFF
--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -248,20 +248,17 @@ pub async fn get_tiles(
         metrics.incr_with_tags("filter.adm.empty_response", Some(tags));
     }
 
-    let filtered: Vec<Tile> = response
-        .tiles
-        .into_iter()
-        .filter_map(|tile| {
-            state.filter.read().unwrap().filter_and_process(
-                tile,
-                location,
-                &device_info,
-                tags,
-                metrics,
-            )
-        })
-        .take(settings.adm_max_tiles as usize)
-        .collect();
+    let filtered: Vec<Tile> = {
+        let filter = state.filter.read().await;
+        response
+            .tiles
+            .into_iter()
+            .filter_map(|tile| {
+                filter.filter_and_process(tile, location, &device_info, tags, metrics)
+            })
+            .take(settings.adm_max_tiles as usize)
+            .collect()
+    };
 
     let mut tiles: Vec<Tile> = Vec::new();
     for mut tile in filtered {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,7 @@
 //! Main application server
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
 
 use actix_cors::Cors;
 use actix_web::{
@@ -121,7 +122,7 @@ impl Server {
             raw_filter.update(&storage_client).await?
         }
         let filter = Arc::new(RwLock::new(raw_filter));
-        spawn_updater(&filter, storage_client)?;
+        spawn_updater(&filter, storage_client).await?;
         let tiles_cache = cache::TilesCache::new(TILES_CACHE_INITIAL_CAPACITY);
         let img_store = ImageStore::create(&settings, Arc::clone(&metrics), &req).await?;
         let excluded_dmas = if let Some(exclude_dmas) = &settings.exclude_dma {

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -51,7 +51,7 @@ pub async fn get_tiles(
     if !state
         .filter
         .read()
-        .unwrap()
+        .await
         .all_include_regions
         .contains(&location.country())
     {

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use actix_cors::Cors;
@@ -15,6 +15,7 @@ use actix_web::{
 use cadence::{SpyMetricSink, StatsdClient};
 use futures::{channel::mpsc, StreamExt};
 use serde_json::{json, Value};
+use tokio::sync::RwLock;
 use url::Url;
 
 use crate::{


### PR DESCRIPTION
This fixes [CONSVC-1794](https://mozilla-hub.atlassian.net/browse/CONSVC-1794), picking it up now since it's blocking the Test Engineering team.

Alternatively, we could also fix this Clippy warning by simply silencing it, but I thought it should be an easy fix by replacing `std::sync::RwLock` with `tokio::sync::RwLock`. That mutable reference of `Tags`, which was used in various places, made this refactor trickier. I ended up using `DashMap`, which provides interior mutation, as the backing store for `Tags` so that we don't need to wrap it into `Arc<RwLock<Tags>>`.

Let me know what you think.      