### PR TITLE
Return JSON in response content for smoke tests

### DIFF
--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -2,4 +2,25 @@
 
 This directory contains code for a smoke-test suite for Contile deployments.
 
-**Please note that this is work in progress.** 🚧
+## Setup
+
+Set runtime environment variables for the `runner` function that contain trigger
+URLs for the clients using the following naming scheme:
+
+`CLIENT_URL_<COUNTRY_CODE>`
+
+Examples:
+```
+CLIENT_URL_US
+CLIENT_URL_GB
+CLIENT_URL_CH
+```
+
+## Example runner invocation
+
+```bash
+curl -m 70 -X POST <RUNNER_TRIGGER_URL> \
+-H "Authorization:bearer $(gcloud auth print-identity-token)" \
+-H "Content-Type:application/json" \
+-d '{"environments": ["STAGE", "PROD"]}'
+```

--- a/smoke-tests/client/main.py
+++ b/smoke-tests/client/main.py
@@ -81,6 +81,7 @@ def run_geo_smoke_test(request: Request):
 
     location_url = f"{env.value}{LOCATION_ENDPOINT}"
 
+    # Send a HTTP request to the Contile "location test" API endpoint
     loc_response = requests.get(location_url)
 
     if loc_response.status_code != 200:

--- a/smoke-tests/runner/main.py
+++ b/smoke-tests/runner/main.py
@@ -28,7 +28,7 @@ class Clients(Enum):
     """Enum with clients deployed as Cloud Functions."""
 
     US: Client = Client(country="US", region="OR", gcp_region="us-west1")
-    GB: Client = Client(country="GB", region="LND", gcp_region="europe-west2")
+    GB: Client = Client(country="GB", region="ENG", gcp_region="europe-west2")
     CH: Client = Client(country="CH", region="ZH", gcp_region="europe-west6")
 
 
@@ -106,10 +106,13 @@ def run_geo_smoke_tests(request: Request):
                     "expected_country": client.value.country,
                     "expected_region": client.value.region,
                 },
-                headers={"Authorization": f"Bearer {id_token}"},
+                headers={
+                    "Authorization": f"Bearer {id_token}",
+                    "Accept": "application/json",
+                },
             )
             response_data.results[env.name][client.name] = ClientResponse(
-                status_code=response.status_code, content=response.text
+                status_code=response.status_code, content=response.json()
             )
 
     return jsonify(asdict(response_data))


### PR DESCRIPTION
## Description

This changes the runner Cloud Function to return the response content from clients as JSON.

cc @dlactin 

## Testing

Deploy the Cloud Function, go to Testing and check that reponses from the runner now contain client errors as JSON.

## Issue(s)

[CONSVC-1795](https://mozilla-hub.atlassian.net/browse/CONSVC-1795)
