### PR TITLE
Upgrade contile-integration-tests Docker images v22.1.2

### DIFF
--- a/contract-tests/docker-compose.yml
+++ b/contract-tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   partner:
-    image: mozilla/contile-integration-tests-partner:22.1.0
+    image: mozilla/contile-integration-tests-partner:22.1.1
     container_name: partner
     environment:
       PORT: 5000
@@ -52,7 +52,7 @@ services:
     #entrypoint: >
     #  /bin/sh -c "hostname -I && bin/contile"
   client:
-    image: mozilla/contile-integration-tests-client:22.1.0
+    image: mozilla/contile-integration-tests-client:22.1.1
     container_name: client
     depends_on:
       - partner

--- a/contract-tests/docker-compose.yml
+++ b/contract-tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   partner:
-    image: mozilla/contile-integration-tests-partner:22.1.1
+    image: mozilla/contile-integration-tests-partner:22.1.2
     container_name: partner
     environment:
       PORT: 5000
@@ -52,7 +52,7 @@ services:
     #entrypoint: >
     #  /bin/sh -c "hostname -I && bin/contile"
   client:
-    image: mozilla/contile-integration-tests-client:22.1.1
+    image: mozilla/contile-integration-tests-client:22.1.2
     container_name: client
     depends_on:
       - partner


### PR DESCRIPTION
## Description
For reference: https://github.com/mozilla-services/contile-integration-tests/releases/tag/22.1.2

## Issue(s)
[CONSVC-1785](https://mozilla-hub.atlassian.net/browse/CONSVC-1785)