### PR TITLE
test: add capability of querying and clearing record of requests to partner API

### DIFF
--- a/test-engineering/contract-tests/partner/Dockerfile
+++ b/test-engineering/contract-tests/partner/Dockerfile
@@ -38,4 +38,4 @@ USER app
 
 EXPOSE ${PORT}
 ENTRYPOINT [ "./entrypoint.sh" ]
-CMD ["gunicorn","-c", "config/gunicorn_conf.py", "-k", "uvicorn.workers.UvicornWorker", "main:app"]
+CMD ["gunicorn","-c", "config/gunicorn_conf.py", "--preload", "-k", "uvicorn.workers.UvicornWorker", "main:app"]

--- a/test-engineering/contract-tests/partner/README.md
+++ b/test-engineering/contract-tests/partner/README.md
@@ -75,20 +75,8 @@ Body:
           "value": "application/json"
         }
       ],
-      "path":"/tilesp/desktop",
-      "query_parameters": {
-        "partner": "demofeed",
-        "sub1": "123456789",
-        "sub2": "placement1",
-        "country-code": "US",
-        "region-code": "NY",
-        "dma-code": "532",
-        "form-factor": "desktop",
-        "os-family": "macos",
-        "v": "1.0",
-        "out": "json",
-        "results": "2"
-      }
+      "path": "/tilesp/desktop",
+      "query": "partner=demofeed&sub1=123456789&sub2=placement1&country-code=US&region-code=NY&dma-code=532&form-factor=desktop&os-family=macos&v=1.0&out=json&results=2"
     }
   ]
 }

--- a/test-engineering/contract-tests/partner/README.md
+++ b/test-engineering/contract-tests/partner/README.md
@@ -31,18 +31,84 @@ You can run the service using `docker compose` from the root directory:
 docker compose run -p 5000:5000 partner
 ```
 
-## Tiles API
+## API
 
-Example request:
+Once the API service is running, API documentation can be found at http://0.0.0.0:5000/docs
+
+### Records
+
+Example GET request:
 
 ```text
 curl \
   -X 'GET' \
   -H 'accept: application/json' \
-  'http://0.0.0.0:5000/tilesp?partner=demofeed&sub1=123456789&sub2=placement1&country-code=US&region-code=NY&form-factor=desktop&os-family=macos&v=1.0&out=json&results=2'
+  'http://0.0.0.0:5000/records/'
 ```
 
-Example response body:
+Example GET response body:
+
+```json
+{
+  "records": [
+    {
+      "method": "GET",
+      "headers": [
+        {
+          "name": "host",
+          "value": "0.0.0.0:5000"
+        },
+        {
+          "name": "user-agent",
+          "value": "curl/7.79.1"
+        },
+        {
+          "name": "accept",
+          "value": "application/json"
+        }
+      ],
+      "path": {
+        "endpoint": "desktop"
+      },
+      "query": {
+        "partner": "demofeed",
+        "sub1": "123456789",
+        "sub2": "placement1",
+        "country-code": "US",
+        "region-code": "NY",
+        "dma-code": "532",
+        "form-factor": "desktop",
+        "os-family": "macos",
+        "v": "1.0",
+        "out": "json",
+        "results": "2"
+      }
+    }
+  ]
+}
+```
+
+Example DELETE request:
+
+```text
+curl \
+  -X 'DELETE' \
+  -H 'accept: */*' \
+  'http://0.0.0.0:5000/records/'
+```
+
+### Tiles
+
+Example GET request:
+
+```text
+curl \
+  -X 'GET' \
+  -H 'accept: application/json' \
+  'http://0.0.0.0:5000/tilesp/desktop?partner=demofeed&sub1=123456789&sub2=placement1&country-code=US&region-code=NY&dma-code=532&form-factor=desktop&os-family=macos&v=1.0&out=json&results=2'
+```
+
+Example GET response body:
 
 ```json
 {

--- a/test-engineering/contract-tests/partner/README.md
+++ b/test-engineering/contract-tests/partner/README.md
@@ -38,7 +38,7 @@ Once the API service is running, API documentation can be found at
 
 ### Records
 
-**GET**: Endpoint to retrieve all historical Contile request records.
+**GET**: Endpoint to retrieve all historical Contile request records with a counter.
 
 Example: 
 
@@ -60,23 +60,38 @@ Body:
 {
   "records": [
     {
-      "method": "GET",
-      "headers": [
-        {
-          "name": "host",
-          "value": "0.0.0.0:5000"
-        },
-        {
-          "name": "user-agent",
-          "value": "curl/7.79.1"
-        },
-        {
-          "name": "accept",
-          "value": "application/json"
+      "count": 1,
+      "record": {
+        "method": "GET",
+        "headers": [
+          {
+            "name": "host",
+            "value": "0.0.0.0:5000"
+          },
+          {
+            "name": "user-agent",
+            "value": "curl/7.79.1"
+          },
+          {
+            "name": "accept",
+            "value": "application/json"
+          }
+        ],
+        "path": "/tilesp/desktop",
+        "query_parameters": {
+          "partner": "demofeed",
+          "sub1": "123456789",
+          "sub2": "placement1",
+          "country-code": "US",
+          "region-code": "NY",
+          "dma-code": "532",
+          "form-factor": "desktop",
+          "os-family": "macos",
+          "v": "1.0",
+          "out": "json",
+          "results": "2"
         }
-      ],
-      "path": "/tilesp/desktop",
-      "query": "partner=demofeed&sub1=123456789&sub2=placement1&country-code=US&region-code=NY&dma-code=532&form-factor=desktop&os-family=macos&v=1.0&out=json&results=2"
+      }
     }
   ]
 }

--- a/test-engineering/contract-tests/partner/README.md
+++ b/test-engineering/contract-tests/partner/README.md
@@ -78,19 +78,52 @@ Body:
           }
         ],
         "path": "/tilesp/desktop",
-        "query_parameters": {
-          "partner": "demofeed",
-          "sub1": "123456789",
-          "sub2": "placement1",
-          "country-code": "US",
-          "region-code": "NY",
-          "dma-code": "532",
-          "form-factor": "desktop",
-          "os-family": "macos",
-          "v": "1.0",
-          "out": "json",
-          "results": "2"
-        }
+        "query_parameters": [
+          {
+            "name": "partner",
+            "value": "demofeed"
+          },
+          {
+            "name": "sub1",
+            "value": "123456789"
+          },
+          {
+            "name": "sub2",
+            "value": "placement1"
+          },
+          {
+            "name": "country-code",
+            "value": "US"
+          },
+          {
+            "name": "region-code",
+            "value": "NY"
+          },
+          {
+            "name": "dma-code",
+            "value": "532"
+          },
+          {
+            "name": "form-factor",
+            "value": "desktop"
+          },
+          {
+            "name": "os-family",
+            "value": "macos"
+          },
+          {
+            "name": "v",
+            "value": "1.0"
+          },
+          {
+            "name": "out",
+            "value": "json"
+          },
+          {
+            "name": "results",
+            "value": "2"
+          }
+        ]
       }
     }
   ]

--- a/test-engineering/contract-tests/partner/README.md
+++ b/test-engineering/contract-tests/partner/README.md
@@ -33,11 +33,16 @@ docker compose run -p 5000:5000 partner
 
 ## API
 
-Once the API service is running, API documentation can be found at http://0.0.0.0:5000/docs
+Once the API service is running, API documentation can be found at 
+`http://0.0.0.0:5000/docs`.
 
 ### Records
 
-Example GET request:
+**GET**: Endpoint to retrieve all historical Contile request records.
+
+Example: 
+
+Request
 
 ```text
 curl \
@@ -46,8 +51,11 @@ curl \
   'http://0.0.0.0:5000/records/'
 ```
 
-Example GET response body:
+Response:
 
+Code: `200`
+
+Body:
 ```json
 {
   "records": [
@@ -67,10 +75,8 @@ Example GET response body:
           "value": "application/json"
         }
       ],
-      "path": {
-        "endpoint": "desktop"
-      },
-      "query": {
+      "path":"/tilesp/desktop",
+      "query_parameters": {
         "partner": "demofeed",
         "sub1": "123456789",
         "sub2": "placement1",
@@ -88,7 +94,11 @@ Example GET response body:
 }
 ```
 
-Example DELETE request:
+**DELETE**: Endpoint to delete all historical Contile request records.
+
+Example:
+
+Request
 
 ```text
 curl \
@@ -97,9 +107,19 @@ curl \
   'http://0.0.0.0:5000/records/'
 ```
 
+Response
+
+Code: `204`
+
+Body: `N/A`
+
 ### Tiles
 
-Example GET request:
+**GET**: Endpoint for requests from Contile.
+
+Example:
+
+Request
 
 ```text
 curl \
@@ -108,7 +128,11 @@ curl \
   'http://0.0.0.0:5000/tilesp/desktop?partner=demofeed&sub1=123456789&sub2=placement1&country-code=US&region-code=NY&dma-code=532&form-factor=desktop&os-family=macos&v=1.0&out=json&results=2'
 ```
 
-Example GET response body:
+Response
+
+Code: `200`
+
+Body:
 
 ```json
 {

--- a/test-engineering/contract-tests/partner/app/main.py
+++ b/test-engineering/contract-tests/partner/app/main.py
@@ -83,7 +83,7 @@ async def read_root():
 
 @app.get("/records/", response_model=Records, status_code=200)
 async def read_records():
-    """Endpoint to retrieve all historical Contile request records."""
+    """Endpoint to retrieve all historical Contile request records with a counter."""
 
     return record_keeper.get_all()
 

--- a/test-engineering/contract-tests/partner/app/main.py
+++ b/test-engineering/contract-tests/partner/app/main.py
@@ -88,7 +88,7 @@ async def read_records():
     return record_keeper.get_all()
 
 
-@app.delete("/records/", response_class=Response, status_code=204)
+@app.delete("/records/", status_code=204)
 async def delete_records():
     """Endpoint to delete all historical Contile request records."""
 

--- a/test-engineering/contract-tests/partner/app/main.py
+++ b/test-engineering/contract-tests/partner/app/main.py
@@ -83,7 +83,7 @@ async def read_root():
 
 @app.get("/records/", response_model=Records, status_code=200)
 async def read_records():
-    """Endpoint for historical Contile request records."""
+    """Endpoint to retrieve all historical Contile request records."""
 
     return record_keeper.get_all()
 

--- a/test-engineering/contract-tests/partner/app/models.py
+++ b/test-engineering/contract-tests/partner/app/models.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 
 from pydantic import BaseModel
 
@@ -38,3 +38,18 @@ class ResponseFromFile(BaseModel):
     headers: List[Header]
     content: Union[Tiles, Any]
     delay: float = 0.0
+
+
+class Record(BaseModel):
+    """Model that represents a request sent by Contile."""
+
+    method: str
+    headers: List[Header]
+    path: str
+    query_parameters: Dict
+
+
+class Records(BaseModel):
+    """Model for a list of requests sent by Contile."""
+
+    records: List[Record]

--- a/test-engineering/contract-tests/partner/app/models.py
+++ b/test-engineering/contract-tests/partner/app/models.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from pydantic import BaseModel
 
@@ -27,6 +27,9 @@ class Tiles(BaseModel):
 class Header(BaseModel):
     """Model that represents a HTTP header."""
 
+    class Config:
+        frozen = True
+
     name: str
     value: str
 
@@ -40,20 +43,33 @@ class ResponseFromFile(BaseModel):
     delay: float = 0.0
 
 
+class QueryParameter(BaseModel):
+    """Model that represents a HTTP query parameter."""
+
+    class Config:
+        frozen = True
+
+    name: str
+    value: str
+
+
 class Record(BaseModel):
     """Model that represents a request sent by Contile."""
 
+    class Config:
+        frozen = True
+
     method: str
-    headers: List[Header]
+    headers: Tuple[Header, ...]
     path: str
-    query_parameters: Dict[str, Any]
+    query_parameters: Tuple[QueryParameter, ...]
 
 
 class RecordCount(BaseModel):
     """Model that represents the number of times a request is sent by Contile."""
 
-    count: int
     record: Record
+    count: int
 
 
 class Records(BaseModel):

--- a/test-engineering/contract-tests/partner/app/models.py
+++ b/test-engineering/contract-tests/partner/app/models.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 from pydantic import BaseModel
 
@@ -68,8 +68,8 @@ class Record(BaseModel):
 class RecordCount(BaseModel):
     """Model that represents the number of times a request is sent by Contile."""
 
-    record: Record
     count: int
+    record: Record
 
 
 class Records(BaseModel):

--- a/test-engineering/contract-tests/partner/app/models.py
+++ b/test-engineering/contract-tests/partner/app/models.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 
 from pydantic import BaseModel
 
@@ -46,7 +46,7 @@ class Record(BaseModel):
     method: str
     headers: List[Header]
     path: str
-    query_parameters: Dict
+    query: str
 
 
 class Records(BaseModel):

--- a/test-engineering/contract-tests/partner/app/models.py
+++ b/test-engineering/contract-tests/partner/app/models.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 
 from pydantic import BaseModel
 
@@ -46,10 +46,17 @@ class Record(BaseModel):
     method: str
     headers: List[Header]
     path: str
-    query: str
+    query_parameters: Dict[str, Any]
+
+
+class RecordCount(BaseModel):
+    """Model that represents the number of times a request is sent by Contile."""
+
+    count: int
+    record: Record
 
 
 class Records(BaseModel):
-    """Model for a list of requests sent by Contile."""
+    """Model for a list of requests sent by Contile and their send count."""
 
-    records: List[Record]
+    records: List[RecordCount]

--- a/test-engineering/contract-tests/partner/app/record_keeper.py
+++ b/test-engineering/contract-tests/partner/app/record_keeper.py
@@ -1,5 +1,5 @@
 from multiprocessing.managers import SyncManager
-from typing import Dict, List
+from typing import List
 
 from fastapi import Request
 
@@ -18,15 +18,13 @@ class RecordKeeper:
         """Create record from Fast API Request and add record to the record keeper."""
 
         headers: List[Header] = [
-            Header(name=header[0], value=header[1])
-            for header in request.headers.items()
+            Header(name=name, value=value) for name, value in request.headers.items()
         ]
-        query_parameters: Dict = dict(request.query_params)
         record: Record = Record(
             method=request.method,
             headers=headers,
             path=request.url.path,
-            query_parameters=query_parameters,
+            query=request.url.query,
         )
         self._records.append(record)
 

--- a/test-engineering/contract-tests/partner/app/record_keeper.py
+++ b/test-engineering/contract-tests/partner/app/record_keeper.py
@@ -1,0 +1,41 @@
+from multiprocessing.managers import SyncManager
+from typing import Dict, List
+
+from fastapi import Request
+
+from models import Header, Record, Records
+
+
+class RecordKeeper:
+    """Responsible for Contile request history management"""
+
+    def __init__(self, multi_process_manager: SyncManager) -> None:
+        """Create an instance of RecordKeeper."""
+
+        self._records: List[Record] = multi_process_manager.list()
+
+    def add(self, request: Request) -> None:
+        """Create record from Fast API Request and add record to the record keeper."""
+
+        headers: List[Header] = [
+            Header(name=header[0], value=header[1])
+            for header in request.headers.items()
+        ]
+        query_parameters: Dict = dict(request.query_params)
+        record: Record = Record(
+            method=request.method,
+            headers=headers,
+            path=request.url.path,
+            query_parameters=query_parameters,
+        )
+        self._records.append(record)
+
+    def clear(self) -> None:
+        """Remove all records from the record keeper."""
+
+        self._records[:] = []
+
+    def get_all(self) -> Records:
+        """Return all records in the record keeper."""
+
+        return Records(records=list(self._records))

--- a/test-engineering/contract-tests/partner/app/record_keeper.py
+++ b/test-engineering/contract-tests/partner/app/record_keeper.py
@@ -3,7 +3,7 @@ from typing import List
 
 from fastapi import Request
 
-from models import Header, Record, Records
+from models import Header, Record, RecordCount, Records
 
 
 class RecordKeeper:
@@ -24,7 +24,7 @@ class RecordKeeper:
             method=request.method,
             headers=headers,
             path=request.url.path,
-            query=request.url.query,
+            query_parameters=dict(request.query_params),
         )
         self._records.append(record)
 
@@ -34,6 +34,14 @@ class RecordKeeper:
         self._records[:] = []
 
     def get_all(self) -> Records:
-        """Return all records in the record keeper."""
+        """Return all records in the record keeper with a counter."""
 
-        return Records(records=list(self._records))
+        records: List[RecordCount] = []
+        for record in list(self._records):
+            record_count = next((rc for rc in records if rc.record == record), None)
+            if record_count:
+                record_count.count += 1
+            else:
+                records.append(RecordCount(count=1, record=record))
+
+        return Records(records=records)

--- a/test-engineering/contract-tests/partner/app/record_keeper.py
+++ b/test-engineering/contract-tests/partner/app/record_keeper.py
@@ -3,6 +3,7 @@ from multiprocessing.managers import SyncManager
 from typing import List, Tuple
 
 from fastapi import Request
+
 from models import Header, QueryParameter, Record, RecordCount, Records
 
 
@@ -42,9 +43,10 @@ class RecordKeeper:
 
     def get_all(self) -> Records:
         """Return all records in the record keeper with a counter."""
-        return Records(
-            records=[
-                RecordCount(record=record, count=count)
-                for record, count in Counter(self._records).items()
-            ]
-        )
+
+        records: List[RecordCount] = [
+            RecordCount(count=count, record=record)
+            for record, count in Counter(self._records).items()
+        ]
+
+        return Records(records=records)


### PR DESCRIPTION
## Description

Add the `records` endpoint to the partner API with GET and DELETE method support. 
The GET method will return the history of calls made by contile to the partner API. It's intended use is to verify the correctness of contile caching. 
The DELETE method will clear the history of calls made by contile to the partner API. It's intended use is in test teardown.

The records are managed and stored in memory through use of the multiprocessing [SyncManager](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.managers.SyncManager). This necessitates the use of the [gunicorn --preload](https://docs.gunicorn.org/en/stable/settings.html#preload-app) option.

## Issue(s)
[CONSVC-1279](https://mozilla-hub.atlassian.net/browse/CONSVC-1279)
[CONSVC-1867](https://mozilla-hub.atlassian.net/browse/CONSVC-1867)
