### PR TITLE
test: add capability to specify service in client scenarios step

### DIFF
--- a/test-engineering/contract-tests/README.md
+++ b/test-engineering/contract-tests/README.md
@@ -36,12 +36,16 @@ response content, but also the response status code, response headers and even
 delay the response for a period of time, which allows us to effectively test the
 MTS.
 
+For more details see the partner [README][partner_readme]
+
 ### client
 
 The `client` directory contains a Python-based test framework for the
 contract tests. The HTTP client used in the framework requests tiles from the
 MTS and performs checks against the responses. The framework implements response
 models for the MTS API.
+
+For more details see the client [README][client_readme]
 
 ### volumes
 
@@ -55,5 +59,7 @@ MTS Docker container such as a partner settings file
 - the `volumes/client` directory contains a YML file which defines every test
 scenario that the contract test suite will run
 
+[client_readme]: ./client/README.md
 [contract-test-repo]: https://github.com/mozilla-services/contile-integration-tests
+[partner_readme]: ./partner/README.md
 [sequence_diagram]: sequence_diagram.png

--- a/test-engineering/contract-tests/client/README.md
+++ b/test-engineering/contract-tests/client/README.md
@@ -1,6 +1,112 @@
 # client
 
-This directory contains a Python-based test framework for the integration
-tests. The HTTP client used in the framework requests tiles from the MTS and
-performs checks against the responses. The framework implements response models
-for the MTS API.
+This directory contains a Python-based test framework for the contract tests.
+The HTTP client used in the framework supports:
+
+* Requests for tiles from the MTS, with response checks. 
+* Requests for partner request history, with response checks.
+
+The framework implements response models for the MTS and partner APIs.
+
+For more details on contract test design, refer to the contile-contract-tests
+[README][contract_tests_readme]
+
+## Scenarios
+
+The client is instructed on request and response check actions via steps recorded in a 
+scenario file. A scenario is defined by a name, description and steps.
+
+### Steps
+
+#### Contile Service
+
+* To direct requests to the MTS service, set the `service` value of `request` to 
+'contile'
+* The expected content for a '200 OK' response is a collection of Tiles.
+
+Example:
+
+      - request:
+          service: 'contile'
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 12345
+                name: 'Example COM'
+                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/desktop_windows01.jpg'
+                image_size: null
+                impression_url: 'https://example.com/desktop_windows?id=0001'
+                url: 'https://www.example.com/desktop_windows'
+              - id: 56789
+                name: 'Example ORG'
+                click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/desktop_windows02.jpg'
+                image_size: null
+                impression_url: 'https://example.org/desktop_windows?id=0002'
+                url: 'https://www.example.org/desktop_windows'
+
+#### partner Service
+
+* To direct requests to the partner service, set the `service` value of `request` to 
+'partner'
+* The expected content for a '200 OK' response is a collection of Records.
+    * Each `record` represents a distinct request made by the MTS to the partner.
+    * The frequency of a request is denoted by the `count`.
+* Request history is cleared between scenarios
+
+Example:
+
+      - request:
+          service: 'partner'
+          method: GET
+          path: '/records/'
+          headers:
+            - name: 'accept'
+              value: '*/*'
+        response:
+          status_code: 200
+          content:
+            records:
+              - count: 1
+                record:
+                  method: 'GET'
+                  headers:
+                    - name: 'accept'
+                      value: '*/*'
+                    - name: 'user-agent'
+                      value: 'contile/1.8.0'
+                    - name: 'host'
+                      value: 'partner:5000'
+                  path: '/tilesp/desktop'
+                  query_parameters:
+                    - name: 'partner'
+                      value: 'partner_id_test'
+                    - name: 'sub1'
+                      value: 'sub1_test'
+                    - name: 'sub2'
+                      value: 'newtab'
+                    - name: 'country-code'
+                      value: 'US'
+                    - name: 'region-code'
+                      value: ''
+                    - name: 'dma-code'
+                      value: ''
+                    - name: 'form-factor'
+                      value: 'desktop'
+                    - name: 'os-family'
+                      value: 'windows'
+                    - name: 'v'
+                      value: '1.0'
+                    - name: 'out'
+                      value: 'json'
+                    - name: 'results'
+                      value: '5'
+
+[contract_tests_readme]: ../README.md

--- a/test-engineering/contract-tests/client/README.md
+++ b/test-engineering/contract-tests/client/README.md
@@ -23,7 +23,7 @@ scenario file. A scenario is defined by a name, description and steps.
 
 * To direct requests to the MTS service, set the `service` value of `request` to 
 `contile`
-* The expected content for a '200 OK' response is a collection of Tiles.
+* The expected content for a `200 OK` response is a collection of tiles.
 
 Example:
 ```yaml
@@ -54,11 +54,11 @@ Example:
           url: 'https://www.example.org/desktop_windows'
 ```
 
-#### partner Service
+#### Partner Service
 
 * To direct requests to the partner service, set the `service` value of `request` to 
 `partner`
-* The expected content for a '200 OK' response is a collection of Records.
+* The expected content for a `200 OK` response is a collection of records.
     * Each `record` represents a distinct request made by the MTS to the partner.
     * The frequency of a request is denoted by the `count`.
 * Request history is cleared between scenarios

--- a/test-engineering/contract-tests/client/README.md
+++ b/test-engineering/contract-tests/client/README.md
@@ -4,12 +4,13 @@ This directory contains a Python-based test framework for the contract tests.
 The HTTP client used in the framework supports:
 
 * Requests for tiles from the MTS, with response checks. 
-* Requests for partner request history, with response checks.
+* Requests for the history of requests from the MTS to the partner API with response 
+checks.
 
 The framework implements response models for the MTS and partner APIs.
 
 For more details on contract test design, refer to the contile-contract-tests
-[README][contract_tests_readme]
+[README][contract_tests_readme].
 
 ## Scenarios
 
@@ -21,92 +22,94 @@ scenario file. A scenario is defined by a name, description and steps.
 #### Contile Service
 
 * To direct requests to the MTS service, set the `service` value of `request` to 
-'contile'
+`contile`
 * The expected content for a '200 OK' response is a collection of Tiles.
 
 Example:
-
-      - request:
-          service: 'contile'
-          method: GET
-          path: '/v1/tiles'
-          headers:
-            - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
-        response:
-          status_code: 200
-          content:
-            tiles:
-              - id: 12345
-                name: 'Example COM'
-                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
-                image_url: 'https://example.com/desktop_windows01.jpg'
-                image_size: null
-                impression_url: 'https://example.com/desktop_windows?id=0001'
-                url: 'https://www.example.com/desktop_windows'
-              - id: 56789
-                name: 'Example ORG'
-                click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-                image_url: 'https://example.org/desktop_windows02.jpg'
-                image_size: null
-                impression_url: 'https://example.org/desktop_windows?id=0002'
-                url: 'https://www.example.org/desktop_windows'
+```yaml
+- request:
+    service: contile
+    method: GET
+    path: '/v1/tiles'
+    headers:
+      - name: User-Agent
+        value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+  response:
+    status_code: 200
+    content:
+      tiles:
+        - id: 12345
+          name: 'Example COM'
+          click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+          image_url: 'https://example.com/desktop_windows01.jpg'
+          image_size: null
+          impression_url: 'https://example.com/desktop_windows?id=0001'
+          url: 'https://www.example.com/desktop_windows'
+        - id: 56789
+          name: 'Example ORG'
+          click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+          image_url: 'https://example.org/desktop_windows02.jpg'
+          image_size: null
+          impression_url: 'https://example.org/desktop_windows?id=0002'
+          url: 'https://www.example.org/desktop_windows'
+```
 
 #### partner Service
 
 * To direct requests to the partner service, set the `service` value of `request` to 
-'partner'
+`partner`
 * The expected content for a '200 OK' response is a collection of Records.
     * Each `record` represents a distinct request made by the MTS to the partner.
     * The frequency of a request is denoted by the `count`.
 * Request history is cleared between scenarios
 
 Example:
-
-      - request:
-          service: 'partner'
-          method: GET
-          path: '/records/'
-          headers:
-            - name: 'accept'
-              value: '*/*'
-        response:
-          status_code: 200
-          content:
-            records:
-              - count: 1
-                record:
-                  method: 'GET'
-                  headers:
-                    - name: 'accept'
-                      value: '*/*'
-                    - name: 'user-agent'
-                      value: 'contile/1.8.0'
-                    - name: 'host'
-                      value: 'partner:5000'
-                  path: '/tilesp/desktop'
-                  query_parameters:
-                    - name: 'partner'
-                      value: 'partner_id_test'
-                    - name: 'sub1'
-                      value: 'sub1_test'
-                    - name: 'sub2'
-                      value: 'newtab'
-                    - name: 'country-code'
-                      value: 'US'
-                    - name: 'region-code'
-                      value: ''
-                    - name: 'dma-code'
-                      value: ''
-                    - name: 'form-factor'
-                      value: 'desktop'
-                    - name: 'os-family'
-                      value: 'windows'
-                    - name: 'v'
-                      value: '1.0'
-                    - name: 'out'
-                      value: 'json'
-                    - name: 'results'
-                      value: '5'
+```yaml
+- request:
+    service: partner
+    method: GET
+    path: '/records/'
+    headers:
+      - name: 'accept'
+        value: '*/*'
+  response:
+    status_code: 200
+    content:
+      records:
+        - count: 1
+          record:
+            method: GET
+            headers:
+              - name: accept
+                value: '*/*'
+              - name: user-agent
+                value: 'contile/1.8.0'
+              - name: host
+                value: 'partner:5000'
+            path: '/tilesp/desktop'
+            query_parameters:
+              - name: partner
+                value: 'partner_id_test'
+              - name: sub1
+                value: 'sub1_test'
+              - name: sub2
+                value: 'newtab'
+              - name: country-code
+                value: 'US'
+              - name: region-code
+                value: ''
+              - name: dma-code
+                value: ''
+              - name: form-factor
+                value: 'desktop'
+              - name: os-family
+                value: 'windows'
+              - name: v
+                value: '1.0'
+              - name: out
+                value: 'json'
+              - name: results
+                value: '5'
+```
 
 [contract_tests_readme]: ../README.md

--- a/test-engineering/contract-tests/client/tests/conftest.py
+++ b/test-engineering/contract-tests/client/tests/conftest.py
@@ -11,7 +11,8 @@ import yaml
 
 from models import Records, Scenario, Service, Tiles
 
-SERVICE_MODEL: Dict[Service, Union[Type[Records], Type[Tiles]]] = {
+SERVICE_MODEL = Union[Type[Records], Type[Tiles]]
+SERVICE_MODELS: Dict[Service, SERVICE_MODEL] = {
     Service.PARTNER: Records,
     Service.CONTILE: Tiles,
 }
@@ -37,9 +38,7 @@ def pytest_configure(config):
             if step.response.status_code != 200:
                 continue
 
-            expected_model: Union[Type[Records], Type[Tiles]] = SERVICE_MODEL.get(
-                step.request.service
-            )
+            expected_model: SERVICE_MODEL = SERVICE_MODELS.get(step.request.service)
 
             if not isinstance(step.response.content, expected_model):
                 raise pytest.UsageError(

--- a/test-engineering/contract-tests/client/tests/conftest.py
+++ b/test-engineering/contract-tests/client/tests/conftest.py
@@ -11,6 +11,7 @@ import yaml
 
 from models import Records, Scenario, Service, Tiles
 
+
 SERVICE_MODEL = Union[Type[Records], Type[Tiles]]
 SERVICE_MODELS: Dict[Service, SERVICE_MODEL] = {
     Service.PARTNER: Records,

--- a/test-engineering/contract-tests/client/tests/exceptions.py
+++ b/test-engineering/contract-tests/client/tests/exceptions.py
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from requests import Response as RequestsResponse
+
+
+class PartnerError(Exception):
+    """Error specific to partner service interactions."""
+
+
+class PartnerRecordsNotClearedError(PartnerError):
+    """Error clearing partner records."""
+
+    def __init__(self, response: RequestsResponse):
+        error_message: str = (
+            f"The Partner records may not have cleared after the test execution.\n"
+            f"Response details:\n"
+            f"Status Code: {response.status_code}\n"
+            f"Content: '{response.text}'"
+        )
+        super().__init__(error_message)

--- a/test-engineering/contract-tests/client/tests/models.py
+++ b/test-engineering/contract-tests/client/tests/models.py
@@ -6,7 +6,6 @@ from enum import Enum
 from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, Extra
-from requests import Response as RequestsResponse
 
 
 class Service(Enum):
@@ -100,20 +99,3 @@ class Scenario(BaseModel):
     name: str
     description: str
     steps: List[Step]
-
-
-class PartnerError(Exception):
-    """Error specific to partner service interactions."""
-
-
-class PartnerRecordsNotClearedError(PartnerError):
-    """Error clearing partner records."""
-
-    def __init__(self, response: RequestsResponse):
-        error_message: str = (
-            f"The Partner records may not have cleared after the test execution.\n"
-            f"Response details:\n"
-            f"Status Code: {response.status_code}\n"
-            f"Content: '{response.text}'"
-        )
-        super().__init__(error_message)

--- a/test-engineering/contract-tests/client/tests/models.py
+++ b/test-engineering/contract-tests/client/tests/models.py
@@ -2,9 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from enum import Enum
 from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, Extra
+
+
+class Service(Enum):
+    """Enum with contract-test service options."""
+
+    CONTILE: str = "contile"
+    PARTNER: str = "partner"
 
 
 class Header(BaseModel):
@@ -17,9 +25,39 @@ class Header(BaseModel):
 class Request(BaseModel):
     """Class that holds information about a HTTP request to Contile."""
 
+    service: Service
     method: str
     path: str
     headers: List[Header] = []
+
+
+class QueryParameter(BaseModel):
+    """Model that represents a HTTP query parameter."""
+
+    name: str
+    value: str
+
+
+class Record(BaseModel):
+    """Model that represents a request sent by Contile."""
+
+    method: str
+    headers: List[Header]
+    path: str
+    query_parameters: List[QueryParameter]
+
+
+class RecordCount(BaseModel):
+    """Model that represents the number of times a request is sent by Contile."""
+
+    count: int
+    record: Record
+
+
+class Records(BaseModel):
+    """Model for a list of requests sent by Contile and their send count."""
+
+    records: List[RecordCount]
 
 
 class Tile(BaseModel, extra=Extra.allow):
@@ -44,7 +82,7 @@ class Response(BaseModel):
     """Class that holds information about a HTTP response from Contile."""
 
     status_code: int
-    content: Union[Tiles, Any]
+    content: Union[Records, Tiles, Any]
     headers: List[Header] = []
 
 

--- a/test-engineering/contract-tests/client/tests/models.py
+++ b/test-engineering/contract-tests/client/tests/models.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, Extra
+from requests import Response as RequestsResponse
 
 
 class Service(Enum):
@@ -99,3 +100,20 @@ class Scenario(BaseModel):
     name: str
     description: str
     steps: List[Step]
+
+
+class PartnerError(Exception):
+    """Error specific to partner service interactions."""
+
+
+class PartnerRecordsNotClearedError(PartnerError):
+    """Error clearing partner records."""
+
+    def __init__(self, response: RequestsResponse):
+        error_message: str = (
+            f"The Partner records may not have cleared after the test execution.\n"
+            f"Response details:\n"
+            f"Status Code: {response.status_code}\n"
+            f"Content: '{response.text}'"
+        )
+        super().__init__(error_message)

--- a/test-engineering/contract-tests/client/tests/test_contile.py
+++ b/test-engineering/contract-tests/client/tests/test_contile.py
@@ -3,34 +3,69 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from typing import List
+from typing import Callable, Dict, List
 
 import pytest
 import requests
+from requests.models import Response
+
 from models import Step
 
 
-@pytest.fixture(name="contile_host")
-def fixture_contile_host(request):
-    """Read the contile host from the pytest config."""
+@pytest.fixture(name="hosts", scope="session")
+def fixture_hosts(request) -> Dict[str, str]:
+    """Return a dict mapping from a service name to a host name."""
 
-    return request.config.option.contile_url
+    return {
+        "contile": request.config.option.contile_url,
+        "partner": request.config.option.partner_url,
+    }
 
 
-def test_contile(contile_host: str, steps: List[Step]):
+@pytest.fixture(name="clear_partner_records")
+def fixture_clear_partner_records(hosts) -> Callable:
+    """Clear Contile request history on partner."""
+
+    partner_host = hosts["partner"]
+
+    def _clear_records():
+        r: Response = requests.request("DELETE", f"{partner_host}/records/")
+
+        error_message: str = (
+            f"Request status code was not as expected. Records may not have cleared "
+            f"after test run, details: '{r.text}'."
+        )
+
+        assert r.status_code == 204, error_message
+
+    return _clear_records
+
+
+@pytest.fixture(scope="function", autouse=True)
+def fixture_function_teardown(clear_partner_records: Callable):
+    """Execute instructions after each test."""
+
+    yield  # Allow test to execute
+
+    clear_partner_records()
+
+
+def test_contile(hosts: Dict[str, str], steps: List[Step]):
     """Test for requesting tiles from Contile."""
 
     for step in steps:
         # Each step in a test scenario consists of a request and a response.
         # Use the parameters to perform the request and verify the response.
 
-        method = step.request.method
-        url = f"{contile_host}{step.request.path}"
-        headers = {header.name: header.value for header in step.request.headers}
+        method: str = step.request.method
+        url: str = f"{hosts[step.request.service.value]}{step.request.path}"
+        headers: Dict[str, str] = {
+            header.name: header.value for header in step.request.headers
+        }
 
-        r = requests.request(method, url, headers=headers)
+        r: Response = requests.request(method, url, headers=headers)
 
-        error_message = (
+        error_message: str = (
             f"Expected status code {step.response.status_code},\n"
             f"but the status code in the response from Contile is {r.status_code}.\n"
             f"The response content is '{r.text}'."

--- a/test-engineering/contract-tests/client/tests/test_contile.py
+++ b/test-engineering/contract-tests/client/tests/test_contile.py
@@ -64,7 +64,7 @@ def test_contile(hosts: Dict[Service, str], steps: List[Step]):
 
         error_message: str = (
             f"Expected status code {step.response.status_code},\n"
-            f"but the status code in the response from Contile is "
+            f"but the status code in the response from {step.request.service.name} is "
             f"{response.status_code}.\n"
             f"The response content is '{response.text}'."
         )

--- a/test-engineering/contract-tests/client/tests/test_contile.py
+++ b/test-engineering/contract-tests/client/tests/test_contile.py
@@ -29,10 +29,10 @@ def fixture_clear_partner_records(hosts: Dict[Service, str]) -> Callable:
     partner_host: str = hosts[Service.PARTNER]
 
     def clear_partner_records():
-        request: RequestsResponse = requests.delete(f"{partner_host}/records/")
+        response: RequestsResponse = requests.delete(f"{partner_host}/records/")
 
-        if request.status_code != 204:
-            raise PartnerRecordsNotClearedError(request)
+        if response.status_code != 204:
+            raise PartnerRecordsNotClearedError(response)
 
     return clear_partner_records
 
@@ -59,31 +59,31 @@ def test_contile(hosts: Dict[Service, str], steps: List[Step]):
             header.name: header.value for header in step.request.headers
         }
 
-        request: RequestsResponse = requests.request(method, url, headers=headers)
+        response: RequestsResponse = requests.request(method, url, headers=headers)
 
         error_message: str = (
             f"Expected status code {step.response.status_code},\n"
             f"but the status code in the response from Contile is "
-            f"{request.status_code}.\n"
-            f"The response content is '{request.text}'."
+            f"{response.status_code}.\n"
+            f"The response content is '{response.text}'."
         )
 
-        assert request.status_code == step.response.status_code, error_message
+        assert response.status_code == step.response.status_code, error_message
 
-        if request.status_code == 200:
+        if response.status_code == 200:
             # If the response status code is 200 OK, load the response content
             # into a Python dict and generate a dict from the response model
-            assert request.json() == step.response.content.dict()
+            assert response.json() == step.response.content.dict()
             continue
 
-        if request.status_code == 204:
+        if response.status_code == 204:
             # If the response status code is 204 No Content, load the response content
             # as text and compare against the value in the response model. This
             # should be an empty string.
-            assert request.text == step.response.content
+            assert response.text == step.response.content
             continue
 
         # If the request to Contile was not successful, load the response
         # content into a Python dict and compare against the value in the
         # response model, which is expected to be the Contile error code.
-        assert request.json() == step.response.content
+        assert response.json() == step.response.content

--- a/test-engineering/contract-tests/client/tests/test_contile.py
+++ b/test-engineering/contract-tests/client/tests/test_contile.py
@@ -23,22 +23,24 @@ def fixture_hosts(request) -> Dict[str, str]:
 
 
 @pytest.fixture(name="clear_partner_records")
-def fixture_clear_partner_records(hosts) -> Callable:
+def fixture_clear_partner_records(hosts: Dict[str, str]) -> Callable:
     """Clear Contile request history on partner."""
 
     partner_host = hosts["partner"]
 
-    def _clear_records():
-        r: Response = requests.request("DELETE", f"{partner_host}/records/")
+    def clear_partner_records():
+        r: Response = requests.delete(f"{partner_host}/records/")
 
-        error_message: str = (
-            f"Request status code was not as expected. Records may not have cleared "
-            f"after test run, details: '{r.text}'."
-        )
+        if r.status_code != 204:
+            error_message: str = (
+                f"The Partner records may not have cleared after the test execution.\n"
+                f"Response details:\n"
+                f"Status Code: {r.status_code}\n"
+                f"Content: '{r.text}'"
+            )
+            raise Exception(error_message)
 
-        assert r.status_code == 204, error_message
-
-    return _clear_records
+    return clear_partner_records
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/test-engineering/contract-tests/client/tests/test_contile.py
+++ b/test-engineering/contract-tests/client/tests/test_contile.py
@@ -9,7 +9,8 @@ import pytest
 import requests
 from requests import Response as RequestsResponse
 
-from models import PartnerRecordsNotClearedError, Service, Step
+from exceptions import PartnerRecordsNotClearedError
+from models import Service, Step
 
 
 @pytest.fixture(name="hosts", scope="session")

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -60,9 +60,11 @@ services:
       - partner
       - contile
     links:
+      - partner
       - contile
     environment:
       CONTILE_URL: http://contile:8000
+      PARTNER_URL: http://partner:5000
       SCENARIOS_FILE: /tmp/client/scenarios.yml
     volumes:
       - ./volumes/client:/tmp/client

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -3,7 +3,7 @@ scenarios:
     description: Test that Contile successfully returns tiles for Windows on Desktop.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -30,7 +30,7 @@ scenarios:
                 impression_url: 'https://example.org/desktop_windows?id=0002'
                 url: 'https://www.example.org/desktop_windows'
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -61,7 +61,7 @@ scenarios:
     description: Test that Contile successfully returns tiles for macOS on Desktop.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -92,7 +92,7 @@ scenarios:
     description: Test that Contile returns tiles for Linux on Desktop.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -123,7 +123,7 @@ scenarios:
     description: Test that Contile correctly handles a 500 from the partner API.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -142,7 +142,7 @@ scenarios:
     description: Test that Contile correctly handles invalid tiles responses from the partner API.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -160,7 +160,7 @@ scenarios:
     description: Test that Contile behaves correctly when a request to the partner API times out.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -179,7 +179,7 @@ scenarios:
     description: Test that Contile correctly handles requests from non Firefox clients.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -198,7 +198,7 @@ scenarios:
     description: Test that Contile successfully returns tiles for a specific country and region.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -237,7 +237,7 @@ scenarios:
       image for the ad provider of a tile shipped with Firefox 90.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -270,7 +270,7 @@ scenarios:
                 impression_url: 'https://example.com/gb_desktop_macos?id=0001'
                 url: 'https://www.example.com/gb_desktop_macos'
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -307,7 +307,7 @@ scenarios:
     description: Test that Contile returns a 200 OK with an empty tiles array for excluded regions
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -334,7 +334,7 @@ scenarios:
       `gb_desktop_windows` prefix for DunBroch tiles.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:
@@ -376,7 +376,7 @@ scenarios:
       `gb_desktop_linux/2021` and the additional path segment is not approved.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -3,6 +3,7 @@ scenarios:
     description: Test that Contile successfully returns tiles for Windows on Desktop.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -29,6 +30,7 @@ scenarios:
                 impression_url: 'https://example.org/desktop_windows?id=0002'
                 url: 'https://www.example.org/desktop_windows'
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -59,6 +61,7 @@ scenarios:
     description: Test that Contile successfully returns tiles for macOS on Desktop.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -89,6 +92,7 @@ scenarios:
     description: Test that Contile returns tiles for Linux on Desktop.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -119,6 +123,7 @@ scenarios:
     description: Test that Contile correctly handles a 500 from the partner API.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -137,6 +142,7 @@ scenarios:
     description: Test that Contile correctly handles invalid tiles responses from the partner API.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -154,6 +160,7 @@ scenarios:
     description: Test that Contile behaves correctly when a request to the partner API times out.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -172,6 +179,7 @@ scenarios:
     description: Test that Contile correctly handles requests from non Firefox clients.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -190,6 +198,7 @@ scenarios:
     description: Test that Contile successfully returns tiles for a specific country and region.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -228,6 +237,7 @@ scenarios:
       image for the ad provider of a tile shipped with Firefox 90.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -260,6 +270,7 @@ scenarios:
                 impression_url: 'https://example.com/gb_desktop_macos?id=0001'
                 url: 'https://www.example.com/gb_desktop_macos'
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -296,6 +307,7 @@ scenarios:
     description: Test that Contile returns a 200 OK with an empty tiles array for excluded regions
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -322,6 +334,7 @@ scenarios:
       `gb_desktop_windows` prefix for DunBroch tiles.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:
@@ -363,6 +376,7 @@ scenarios:
       `gb_desktop_linux/2021` and the additional path segment is not approved.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:

--- a/test-engineering/contract-tests/volumes/client/scenarios_204.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios_204.yml
@@ -6,7 +6,7 @@ scenarios:
     # no content if a request is made from an excluded country location.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:

--- a/test-engineering/contract-tests/volumes/client/scenarios_204.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios_204.yml
@@ -6,6 +6,7 @@ scenarios:
     # no content if a request is made from an excluded country location.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:

--- a/test-engineering/contract-tests/volumes/client/scenarios_init_error.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios_init_error.yml
@@ -5,6 +5,7 @@ scenarios:
       contains a prefix path value without a trailing slash character.
     steps:
       - request:
+          service: 'contile'
           method: GET
           path: '/v1/tiles'
           headers:

--- a/test-engineering/contract-tests/volumes/client/scenarios_init_error.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios_init_error.yml
@@ -5,7 +5,7 @@ scenarios:
       contains a prefix path value without a trailing slash character.
     steps:
       - request:
-          service: 'contile'
+          service: contile
           method: GET
           path: '/v1/tiles'
           headers:


### PR DESCRIPTION
## Description

Add a new step type to the Contile contract tests, allowing for verification of the partner request history during scenario execution.

* add capacity to specify either 'contile' or 'partner' service as request target in scenario step request
* add support for Records content in scenario step response
* add teardown which clears records of contile partner requests between tests
* update README documentation

## Issue(s)
[CONSVC-1293](https://mozilla-hub.atlassian.net/browse/CONSVC-1293)
