### PR TITLE
chore: update rust (to 1.62.1, the latest circleci image)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ commands:
 jobs:
   checks:
     docker:
-      - image: circleci/rust:latest
+      - image: cimg/rust:1.62
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -100,7 +100,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/rust:latest
+      - image: cimg/rust:1.62
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -116,7 +116,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/rust:latest
+      - image: cimg/rust:1.62
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ARG APPNAME=contile
 
 # make sure that the build and run environments are the same version
-FROM rust:1.60-slim-buster as builder
+FROM rust:1.62-slim-buster as builder
 ARG APPNAME
 ADD . /app
 WORKDIR /app

--- a/src/server/img_storage.rs
+++ b/src/server/img_storage.rs
@@ -139,7 +139,7 @@ impl StoredImage {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Default, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
 pub struct ImageMetrics {
     pub width: u32,
     pub height: u32,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,7 +14,7 @@ static PREFIX: &str = "contile";
 
 static DEFAULT_PORT: u16 = 8000;
 
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TestModes {
     TestTimeout,
     TestFakeResponse,


### PR DESCRIPTION
switching from the deprecated circleci namespace to cimg and pinning
CI's rust version to match the Dockerfile's

also update clippy per 1.63.0