### PR TITLE
feat: add the fallback protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contile"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -505,6 +505,7 @@ dependencies = [
  "chrono",
  "cloud-storage",
  "config",
+ "crossbeam-channel",
  "dashmap",
  "docopt",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ blake3 = "1"
 bytes = "1"
 cadence = "0.29"
 chrono = "0.4"
+crossbeam-channel = "0.5.4"
 docopt = "1.1"
 cloud-storage = { git = "https://github.com/mozilla-services/cloud-storage-rs", branch = "release/0.11.1-client-builder-and-params" }
 config = "0.13"

--- a/src/adm/filter.rs
+++ b/src/adm/filter.rs
@@ -146,7 +146,7 @@ impl AdmFilter {
         // TODO: if not error.is_reportable, just add to metrics.
         let mut merged_tags = error.tags.clone();
         merged_tags.extend(tags.clone());
-        l_sentry::report(sentry::event_from_error(error), &merged_tags);
+        l_sentry::report(error, &merged_tags);
     }
 
     /// check to see if the bucket has been modified since the last time we updated.

--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -18,7 +18,7 @@ use crate::{
     server::ServerState,
     settings::Settings,
     tags::Tags,
-    web::middleware::sentry::report,
+    web::middleware::sentry as l_sentry,
     web::DeviceInfo,
 };
 
@@ -274,7 +274,7 @@ pub async fn get_tiles(
                 }
                 Err(e) => {
                     // quietly report the error, and drop the tile.
-                    report(sentry::event_from_error(&e), tags);
+                    l_sentry::report(&e, tags);
                     continue;
                 }
             }

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -13,7 +13,9 @@ use actix_web::{
     App, HttpRequest, HttpResponse, HttpServer,
 };
 use cadence::{SpyMetricSink, StatsdClient};
+use crossbeam_channel::Receiver;
 use futures::{channel::mpsc, StreamExt};
+use regex::Regex;
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use url::Url;
@@ -114,6 +116,11 @@ impl MockAdm {
             .into_owned()
             .collect()
     }
+
+    /// Set the mock AdM to respond with a 5xx error
+    fn set_response_error(&mut self) {
+        self.request_rx.close();
+    }
 }
 
 /// Bind a mock of the AdM Tiles API to a random port on localhost
@@ -122,7 +129,7 @@ fn init_mock_adm(response: String) -> MockAdm {
         req: HttpRequest,
         resp: web::Data<String>,
         tx: web::Data<futures::channel::mpsc::UnboundedSender<String>>,
-    ) -> HttpResponse {
+    ) -> actix_web::error::Result<HttpResponse> {
         trace!(
             "mock_adm: path: {:#?} query_string: {:#?} {:#?} {:#?}",
             req.path(),
@@ -132,10 +139,11 @@ fn init_mock_adm(response: String) -> MockAdm {
         );
         // TODO: pass more data for validation
         tx.unbounded_send(req.query_string().to_owned())
-            .expect("Failed to send");
-        HttpResponse::Ok()
+            // set_response_error called
+            .map_err(actix_web::error::ErrorServiceUnavailable)?;
+        Ok(HttpResponse::Ok()
             .content_type("application/json")
-            .body(resp.get_ref().to_owned())
+            .body(resp.get_ref().to_owned()))
     }
 
     let (tx, request_rx) = mpsc::unbounded::<String>();
@@ -188,6 +196,19 @@ pub fn adm_settings() -> AdmFilterSettings {
         }
     });
     AdmFilterSettings::try_from(adm_settings.to_string()).unwrap()
+}
+
+/// Find all metric lines emitted from spy with matching prefixes
+fn find_metrics(spy: &Receiver<Vec<u8>>, prefixes: &[&str]) -> Vec<String> {
+    spy.try_iter()
+        .filter_map(|m| {
+            let m = String::from_utf8(m).unwrap();
+            prefixes
+                .iter()
+                .any(|prefix| m.starts_with(prefix))
+                .then_some(m)
+        })
+        .collect()
 }
 
 /// Basic integration test
@@ -691,18 +712,8 @@ async fn metrics() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::OK);
 
-    // Find all metric lines with matching prefixes
-    let find_metrics = |prefixes: &[&str]| -> Vec<_> {
-        spy.try_iter()
-            .filter_map(|m| {
-                let m = String::from_utf8(m).unwrap();
-                prefixes.iter().any(|name| m.starts_with(name)).then_some(m)
-            })
-            .collect()
-    };
-
     let prefixes = &["contile.tiles.get:1", "contile.tiles.adm.request:1"];
-    let metrics = find_metrics(prefixes);
+    let metrics = find_metrics(&spy, prefixes);
     assert_eq!(metrics.len(), 2);
     let get_metric = &metrics[0];
     assert!(get_metric.contains("ua.form_factor:desktop"));
@@ -716,7 +727,7 @@ async fn metrics() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let metrics = find_metrics(prefixes);
+    let metrics = find_metrics(&spy, prefixes);
     assert_eq!(metrics.len(), 2);
     let get_metric = &metrics[0];
     assert!(get_metric.contains("ua.form_factor:phone"));
@@ -774,4 +785,137 @@ async fn zero_jitter() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[actix_web::test]
+async fn cache_header() {
+    let adm = init_mock_adm(MOCK_RESPONSE1.to_owned());
+    let mut settings = Settings {
+        adm_endpoint_url: adm.endpoint_url.clone(),
+        adm_settings: json!(adm_settings()).to_string(),
+        location_test_header: Some("x-test-location".to_owned()),
+        ..get_test_settings()
+    };
+    let app = init_app!(settings).await;
+
+    let req = test::TestRequest::get()
+        .uri("/v1/tiles")
+        .insert_header((header::USER_AGENT, UA_91))
+        .insert_header(("X-Forwarded-For", TEST_ADDR))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let cache_header = resp
+        .headers()
+        .get("Cache-Control")
+        .expect("No Cache-Control header")
+        .to_str()
+        .expect("Invalid Cache-Control header");
+    let directives: Vec<_> = cache_header.split(", ").collect();
+    assert_eq!(directives.len(), 3);
+    assert_eq!(directives[0], "private");
+
+    /// Parse a numeric value of a header directive into a u32
+    ///
+    /// E.g.:
+    /// find_directive(&vec!["private", "max-age=5"], "max-age") -> 5
+    fn find_directive(directives: &[&str], name: &str) -> u32 {
+        let re = Regex::new(&format!(r"{}=(\d+)", name)).unwrap();
+        directives
+            .iter()
+            .filter_map(|directive| {
+                re.captures(directive)
+                    .and_then(|captures| captures.get(1))
+                    .and_then(|value| value.as_str().parse::<u32>().ok())
+            })
+            .next()
+            .unwrap()
+    }
+
+    assert!(directives
+        .iter()
+        .any(|directive| directive.starts_with("max-age=")));
+    let max_age = find_directive(&directives, "max-age");
+    assert!(max_age > 0);
+    // less than tiles_ttl plus jitter
+    assert!(max_age < settings.tiles_ttl * 2);
+
+    assert!(directives
+        .iter()
+        .any(|directive| directive.starts_with("stale-if-error=")));
+    let stale_if_error = find_directive(&directives, "stale-if-error");
+    assert!(stale_if_error > settings.tiles_ttl);
+    // less than fallback_tiles_ttl plus jitter
+    assert!(stale_if_error < settings.tiles_fallback_ttl * 2);
+
+    let result: Value = test::read_body_json(resp).await;
+    let tiles = result["tiles"].as_array().expect("!tiles.is_array()");
+    assert_eq!(tiles.len(), 2);
+}
+
+#[actix_web::test]
+async fn fallback_on_error() {
+    let mut adm = init_mock_adm(MOCK_RESPONSE1.to_owned());
+    let tiles_ttl = 2;
+    let mut settings = Settings {
+        adm_endpoint_url: adm.endpoint_url.clone(),
+        adm_settings: json!(adm_settings()).to_string(),
+        location_test_header: Some("x-test-location".to_owned()),
+        tiles_ttl,
+        ..get_test_settings()
+    };
+    let (app, spy) = init_app_with_spy!(settings).await;
+
+    // Load the cache
+    let req = test::TestRequest::get()
+        .uri("/v1/tiles")
+        .insert_header((header::USER_AGENT, UA_91))
+        .insert_header(("X-Forwarded-For", TEST_ADDR))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(resp.headers().get("Cache-Control").is_some());
+
+    // Set adM to return an error then trigger a refresh (as the tiles expired)
+    adm.set_response_error();
+    rt::time::sleep(Duration::from_secs(tiles_ttl as u64)).await;
+    let req = test::TestRequest::get()
+        .uri("/v1/tiles")
+        .insert_header((header::USER_AGENT, UA_91))
+        .insert_header(("X-Forwarded-For", TEST_ADDR))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let cache_header = resp
+        .headers()
+        .get("Cache-Control")
+        .expect("No Cache-Control header")
+        .to_str()
+        .expect("Invalid Cache-Control header");
+    let directives: Vec<_> = cache_header.split(", ").collect();
+    assert_eq!(directives[0], "private");
+    // We should fall back on errors, so max-age=0
+    assert!(directives
+        .iter()
+        .any(|directive| directive.starts_with("max-age=0")));
+    assert!(directives
+        .iter()
+        .any(|directive| directive.starts_with("stale-if-error=")));
+
+    let metrics: Vec<_> = find_metrics(&spy, &["contile.tiles."])
+        .into_iter()
+        .map(|m| m.split_once('|').unwrap().0.to_owned())
+        .collect();
+    assert_eq!(
+        metrics,
+        vec![
+            "contile.tiles.get:1",
+            "contile.tiles.adm.request:1",
+            "contile.tiles.get:1",
+            "contile.tiles.adm.request:1",
+            "contile.tiles.get.error:1"
+        ]
+    );
 }


### PR DESCRIPTION
to render Cache-Control headers in most cases

and fix omissions of stack traces to sentry events

Closes #305
Closes #376