### PR TITLE
fix: adm update metrics to be consistent

### DIFF
--- a/src/adm/filter.rs
+++ b/src/adm/filter.rs
@@ -474,13 +474,18 @@ impl AdmFilter {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+    use actix_web::rt;
     use super::{check_url, AdmFilter};
     use crate::adm::settings::AdmAdvertiserSettings;
-    use crate::adm::AdmDefaults;
+    use crate::adm::{AdmDefaults, spawn_updater};
     use crate::adm::{settings::AdvertiserUrlFilter, tiles::AdmTile};
     use crate::tags::Tags;
     use crate::web::test::find_metrics;
-    use cadence::SpyMetricSink;
+    use cadence::{SpyMetricSink, StatsdClient};
+    use tokio::sync::RwLock;
+    use url::Url;
 
     #[test]
     fn check_url_matches() {
@@ -742,9 +747,7 @@ mod tests {
             .check_image_hosts(&defaults, &mut tile, &mut tags)
             .is_ok());
     }
-}
-
-#[actix_web::test]
+    #[actix_web::test]
 async fn check_advertiser_metrics() {
     let s = r#"{"adm_advertisers":{
             "Acme": {
@@ -787,3 +790,6 @@ async fn check_advertiser_metrics() {
     let metrics = find_metrics(&rx, prefixes);
     assert_eq!(metrics.len(), 1);
 }
+
+}
+

--- a/src/adm/filter.rs
+++ b/src/adm/filter.rs
@@ -121,12 +121,13 @@ pub fn spawn_updater(
         let mut tags = crate::tags::Tags::default();
         loop {
             {
+                metrics.incr("filter.adm.update_check").ok();
                 match mfilter.read().await.requires_update(&storage_client).await {
                     Ok(true) => {
-                        metrics.incr("adm.filter.update").ok();
+                        metrics.incr("filter.adm.update").ok();
                         let mut filter = mfilter.write().await;
                         filter.update(&storage_client).await.unwrap_or_else(|e| {
-                            metrics.incr("adm.filter.update.error").ok();
+                            metrics.incr("filter.adm.update.error").ok();
                             filter.report(&e, &mut tags);
                         });
                     }

--- a/src/adm/filter.rs
+++ b/src/adm/filter.rs
@@ -4,7 +4,7 @@ use std::{
 
 use actix_web::{http::Uri, rt};
 use actix_web_location::Location;
-use cadence::{CountedExt, SpyMetricSink, StatsdClient};
+use cadence::{CountedExt, StatsdClient};
 use lazy_static::lazy_static;
 use tokio::sync::RwLock;
 use url::Url;
@@ -13,7 +13,6 @@ use super::{
     settings::AdmAdvertiserSettings,
     tiles::{AdmTile, Tile},
 };
-use crate::web::test::find_metrics;
 use crate::{
     adm::settings::{AdmDefaults, AdvertiserUrlFilter, PathFilter, PathMatching},
     error::{HandlerError, HandlerErrorKind, HandlerResult},
@@ -480,6 +479,8 @@ mod tests {
     use crate::adm::AdmDefaults;
     use crate::adm::{settings::AdvertiserUrlFilter, tiles::AdmTile};
     use crate::tags::Tags;
+    use crate::web::test::find_metrics;
+    use cadence::SpyMetricSink;
 
     #[test]
     fn check_url_matches() {

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -195,7 +195,7 @@ pub fn advertiser_filters() -> AdmAdvertiserSettings {
 }
 
 /// Find all metric lines emitted from spy with matching prefixes
-fn find_metrics(spy: &Receiver<Vec<u8>>, prefixes: &[&str]) -> Vec<String> {
+pub fn find_metrics(spy: &Receiver<Vec<u8>>, prefixes: &[&str]) -> Vec<String> {
     spy.try_iter()
         .filter_map(|m| {
             let m = String::from_utf8(m).unwrap();


### PR DESCRIPTION
Currently, we only have metrics for updates for changes that occur for the adm filters. This made it hard to determine whether there was an attempt at an update or whether there were no changes. Added metrics for check attempts.

In addition, changed metric from adm.filter to filter.adm for consistency