### PR TITLE
fix: use last object modification timestamp for filter updater

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -119,11 +119,11 @@ impl Server {
         let mut partner_filter = HandlerResult::<AdmFilter>::from(&mut settings)?;
         // try to update from the bucket if possible.
         if partner_filter.is_cloud() {
-            let advertiser_settings = partner_filter
+            let (advertiser_settings, last_updated) = partner_filter
                 .fetch_new_settings(&storage_client)
                 .await?
                 .expect("Expected AdmAdvertiserSettings for is_cloud AdmFilter");
-            partner_filter.update(advertiser_settings);
+            partner_filter.update(advertiser_settings, last_updated);
         }
         let refresh_rate = partner_filter.refresh_rate;
         let is_cloud = partner_filter.is_cloud();


### PR DESCRIPTION
The follow-up of #504 to mitigate [this anomaly](https://github.com/mozilla-services/contile/pull/504#discussion_r1071539794).