### PR TITLE
[DISCO-2250] feat: Return 204 for unknown form factors

### DIFF
--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -36,8 +36,7 @@ pub async fn get_tiles(
     trace!("get_tiles");
     metrics.incr("tiles.get");
 
-    let settings = &state.settings;
-    if let Some(response) = maybe_early_respond(&settings, &state, &location, &device_info).await {
+    if let Some(response) = maybe_early_respond(&state, &location, &device_info).await {
         return Ok(response);
     }
     let audience_key = cache::AudienceKey {
@@ -53,6 +52,7 @@ pub async fn get_tiles(
         legacy_only: device_info.legacy_only(),
     };
 
+    let settings = &state.settings;
     let mut tags = Tags::from_head(request.head(), settings);
     {
         tags.add_extra("audience_key", &format!("{:#?}", audience_key));
@@ -205,11 +205,15 @@ fn fallback_response(settings: &Settings, tiles: &cache::Tiles) -> HttpResponse 
 /// It returns a proper response if the early response is desired.
 /// Otherwise, it returns None.
 async fn maybe_early_respond(
-    settings: &Settings,
     state: &web::Data<ServerState>,
     location: &Location,
     device_info: &DeviceInfo,
 ) -> Option<HttpResponse> {
+    if matches!(&device_info.form_factor, FormFactor::Other) {
+        trace!("get_tiles: unknown form factor");
+        return Some(HttpResponse::NoContent().finish());
+    }
+
     if !state
         .partner_filter
         .read()
@@ -221,7 +225,7 @@ async fn maybe_early_respond(
         // Nothing to serve. We typically send a 204 for empty tiles but
         // optionally send 200 to resolve
         // https://github.com/mozilla-services/contile/issues/284
-        let response = if settings.excluded_countries_200 {
+        let response = if state.settings.excluded_countries_200 {
             HttpResponse::Ok()
                 .content_type("application/json")
                 .body(EMPTY_TILES.as_str())
@@ -229,11 +233,6 @@ async fn maybe_early_respond(
             HttpResponse::NoContent().finish()
         };
         return Some(response);
-    }
-
-    if matches!(&device_info.form_factor, FormFactor::Other) {
-        trace!("get_tiles: unknown form factor");
-        return Some(HttpResponse::NoContent().finish());
     }
 
     None

--- a/test-engineering/contract-tests/volumes/client/scenarios_204.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios_204.yml
@@ -23,3 +23,22 @@ scenarios:
         response:
           status_code: 204
           content: ''
+  - name: success_204_No_Content_unknown_form_factor
+    description: Test that Contile returns a 204 No Content for unknown form factors
+    steps:
+      - request:
+          service: contile
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: other and form-factor: other
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Raspberry Pi 3) Gecko/20100101 Firefox/91.0'
+            # The following 'X-Forwarded-For' header value will result in query values
+            # country-code: US, region-code: WA and dma-code: 819
+            - name: X-Forwarded-For
+              value: '216.160.83.62'
+        response:
+          status_code: 204
+          content: ''


### PR DESCRIPTION
Per the partner's request, we don't want to serve tiles for clients if their form factor (device type) is unknown. 

This fixes [DISCO-2250](https://mozilla-hub.atlassian.net/browse/DISCO-2250).

[DISCO-2250]: https://mozilla-hub.atlassian.net/browse/DISCO-2250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ