### PR TITLE
fix: Fix intermittent contract test failures on M1 laptops

### DIFF
--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -59,7 +59,9 @@ services:
       CONTILE_ADM_PARTNER_ID: partner_id_test
       CONTILE_ADM_HAS_LEGACY_IMAGE: '["Example ORG","Example COM"]'
       # Timeout requests to the ADM server after this many seconds (default: 5)
-      CONTILE_ADM_TIMEOUT: 2
+      # Use larger timeouts to mitigate the network latency issues on M1 laptops
+      CONTILE_ADM_TIMEOUT: 10
+      CONTILE_CONNECT_TIMEOUT: 10
       CONTILE_DEBUG: 1
       CONTILE_HOST: 0.0.0.0
       CONTILE_HUMAN_LOGS: 1

--- a/test-engineering/contract-tests/volumes/partner/responses.yml
+++ b/test-engineering/contract-tests/volumes/partner/responses.yml
@@ -62,7 +62,9 @@ phone:
       content: {}
 
     ios:
-      delay: 5.0
+      # Contile uses a 10-seconds timeout in contract tests, make the delay
+      # slightly longer than that
+      delay: 12.0
       status_code: 200
       headers: []
       content:


### PR DESCRIPTION
Sigh, turns out the test failures were caused by the crappy network latency issues (only in docker-compose) on M1 laptops. Increasing both the connection and adm_request timeouts seemed to work, though it will take a little bit longer to finish all the tests, which is still better than failures.

cc: @Trinaa 