### PR TITLE
feat: Add country-code to metric tags for ad fill instrumentation

### DIFF
--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -140,7 +140,7 @@ pub async fn get_tiles(
     let country_code = location
         .country
         .as_deref()
-        .unwrap_or(settings.fallback_country.as_ref());
+        .unwrap_or_else(|| settings.fallback_country.as_ref());
     let adm_url = Url::parse_with_params(
         &pse.endpoint,
         &[

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -880,6 +880,7 @@ async fn metrics() {
     assert!(get_metric.contains("ua.form_factor:desktop"));
     assert!(get_metric.contains("ua.os.family:windows"));
     assert!(!&metrics[1].contains("endpoint:mobile"));
+    assert!(&metrics[1].contains("geo.country_code"));
 
     let req = test::TestRequest::get()
         .uri("/v1/tiles")
@@ -894,6 +895,7 @@ async fn metrics() {
     assert!(get_metric.contains("ua.form_factor:phone"));
     assert!(get_metric.contains("ua.os.family:ios"));
     assert!(&metrics[1].contains("endpoint:mobile"));
+    assert!(&metrics[1].contains("geo.country_code"));
 }
 
 #[actix_web::test]


### PR DESCRIPTION
This fixes [DISCO-2293](https://mozilla-hub.atlassian.net/browse/DISCO-2293).

[DISCO-2293]: https://mozilla-hub.atlassian.net/browse/DISCO-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ