### PR TITLE
feat: Add an `adm_mobile_max_tiles` setting (DISCO-2306)

### DIFF
--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -253,13 +253,20 @@ pub async fn get_tiles(
     let mut filtered: Vec<Tile> = Vec::new();
     let iter = response.tiles.into_iter();
     let filter = state.partner_filter.read().await;
+    let max_tiles = usize::from(if device_info.is_mobile() {
+        settings
+            .adm_mobile_max_tiles
+            .unwrap_or(settings.adm_max_tiles)
+    } else {
+        settings.adm_max_tiles
+    });
     for tile in iter {
         if let Some(tile) =
             filter.filter_and_process(tile, location, &device_info, tags, metrics)?
         {
             filtered.push(tile);
         }
-        if filtered.len() == settings.adm_max_tiles as usize {
+        if filtered.len() == max_tiles {
             break;
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -103,12 +103,14 @@ pub struct Settings {
     pub adm_sub1: Option<String>,
     /// adm Endpoint URL
     pub adm_endpoint_url: String,
+    /// max number of tiles returned to non-mobile clients (default: 3)
+    pub adm_max_tiles: u8,
     /// Mobile versions of the above
     pub adm_mobile_partner_id: Option<String>,
     pub adm_mobile_sub1: Option<String>,
     pub adm_mobile_endpoint_url: Option<String>,
-    /// max number of tiles returned to clients (default: 2)
-    pub adm_max_tiles: u8,
+    /// max number of tiles returned to mobile clients (default: 2)
+    pub adm_mobile_max_tiles: Option<u8>,
     /// number of tiles to query from ADM (default: 10)
     pub adm_query_tile_count: u8,
     /// Timeout requests to the ADM server after this many seconds (default: 5)
@@ -167,10 +169,11 @@ impl Default for Settings {
             adm_endpoint_url: "".to_owned(),
             adm_partner_id: None,
             adm_sub1: None,
+            adm_max_tiles: 3,
             adm_mobile_endpoint_url: None,
             adm_mobile_partner_id: None,
             adm_mobile_sub1: None,
-            adm_max_tiles: 2,
+            adm_mobile_max_tiles: Some(2),
             adm_query_tile_count: 10,
             adm_timeout: 5,
             adm_settings: "".to_owned(),

--- a/src/web/mock_adm_response1.json
+++ b/src/web/mock_adm_response1.json
@@ -23,6 +23,14 @@
             "image_url": "https://cdn.example.com/805.jpg",
             "advertiser_url": "https://www.lph-nm.biz/?utm_source=google&utm_campaign=quux*{keyword}_m*{match-type}_d*BARBAZ_22",
             "impression_url": "https://example.net/static?id=ABAD1DEA"
+        },
+        {
+            "id": 907,
+            "name": "Lasagna Come Out Tomorrow",
+            "click_url": "https://example.com/ctp?version=16.0.0&key=5.5&ci=6.6&ctag=1680739594006000000",
+            "image_url": "https://cdn.example.com/907.jpg",
+            "advertiser_url": "https://www.lasagna.restaurant/?utm_source=google&utm_campaign=xyzzy*{keyword}_m*{match-type}_d*FRED_56",
+            "impression_url": "https://example.net/static?id=CAFED00D"
         }
     ]
 }

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -269,6 +269,13 @@ scenarios:
                 image_size: null
                 impression_url: 'https://example.com/gb_desktop_macos?id=0001'
                 url: 'https://www.example.com/gb_desktop_macos'
+              - id: 76790
+                name: 'Example ORG'
+                click_url: 'https://example.org/gb_desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/gb_desktop_macos02.jpg'
+                image_size: null
+                impression_url: 'https://example.org/gb_desktop_macos?id=0002'
+                url: 'https://www.example.org/gb_desktop_macos'
       - request:
           service: contile
           method: GET
@@ -302,6 +309,36 @@ scenarios:
                 image_size: null
                 impression_url: 'https://example.org/gb_desktop_macos?id=0002'
                 url: 'https://www.example.org/gb_desktop_macos'
+      - request:
+          service: contile
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: ios and form-factor: phone
+            - name: User-Agent
+              value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_8_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/91.0 Mobile/15E148 Safari/605.1.15'
+            # The following value will result in country-code: GB and region-code: ENG
+            - name: X-Forwarded-For
+              value: '81.2.69.192'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 32348
+                name: 'Example COM'
+                click_url: 'https://example.com/gb_phone_ios?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/gb_phone_ios01.jpg'
+                image_size: null
+                impression_url: 'https://example.com/gb_phone_ios?id=0001'
+                url: 'https://www.example.com/gb_phone_ios'
+              - id: 76792
+                name: 'Example ORG'
+                click_url: 'https://example.org/gb_phone_ios?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/gb_phone_ios02.jpg'
+                image_size: null
+                impression_url: 'https://example.org/gb_phone_ios?id=0002'
+                url: 'https://www.example.org/gb_phone_ios'
 
   - name: success_200_OK_excluded_region
     description: Test that Contile returns a 200 OK with an empty tiles array for excluded regions

--- a/test-engineering/contract-tests/volumes/partner/GB/responses.yml
+++ b/test-engineering/contract-tests/volumes/partner/GB/responses.yml
@@ -54,7 +54,7 @@ desktop:
       headers: []
       content:
         tiles:
-          - id: 41236
+          - id: 41237
             name: 'DunBroch'
             click_url: 'https://dunbroch.co.uk/gb_desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
             image_url: 'https://dunbroch.co.uk/gb_desktop_linux01.jpg'
@@ -72,3 +72,28 @@ desktop:
             image_url: 'https://example.org/gb_desktop_linux02.jpg'
             impression_url: 'https://example.org/gb_desktop_linux?id=0002'
             advertiser_url: 'https://www.example.org/gb_desktop_linux'
+
+phone:
+    ios:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 41236
+            name: 'DunBroch'
+            click_url: 'https://dunbroch.co.uk/gb_phone_ios?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://dunbroch.co.uk/gb_phone_ios01.jpg'
+            impression_url: 'https://dunbroch.co.uk/gb_phone_ios?id=0001'
+            advertiser_url: 'https://www.dunbroch.co.uk/gb_phone_ios/2021'
+          - id: 32348
+            name: 'Example COM'
+            click_url: 'https://example.com/gb_phone_ios?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/gb_phone_ios01.jpg'
+            impression_url: 'https://example.com/gb_phone_ios?id=0001'
+            advertiser_url: 'https://www.example.com/gb_phone_ios'
+          - id: 76792
+            name: 'Example ORG'
+            click_url: 'https://example.org/gb_phone_ios?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/gb_phone_ios02.jpg'
+            impression_url: 'https://example.org/gb_phone_ios?id=0002'
+            advertiser_url: 'https://www.example.org/gb_phone_ios'


### PR DESCRIPTION
This commit adds an option to separately control the maximum number of tiles returned to Desktop and mobile clients.

Desktop clients use the `adm_max_tiles` setting now, and mobile clients use `adm_mobile_max_tiles` (falling back to `adm_max_tiles`).