### PR TITLE
Add some commands to run Coverage and Checks locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@ README.md
 target
 
 smoke-tests/
+
+*.profraw

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ venv
 __pycache__/
 *.py[cod]
 .python-version
+
+*.profraw

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-build-dev:
-	cargo build --tests
+build:
+	cargo build
 
-setup-grcov:
-	cargo install grcov
+setup-all: build setup-coverage-tools setup-rust-checks
 
-coverage: build-dev setup-grcov
-	RUSTFLAGS="-C instrument-coverage" cargo test
-	grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
-	rm *.profraw
+setup-coverage-tools:
+	cargo +stable install cargo-llvm-cov --locked
+
+coverage: setup-coverage-tools
+	cargo llvm-cov --open
 
 setup-rust-checks:
 	rustup component add rustfmt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+build-dev:
+	cargo build --tests
+
+setup-grcov:
+	cargo install grcov
+
+coverage: build-dev setup-grcov
+	RUSTFLAGS="-C instrument-coverage" cargo test
+	grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
+	rm *.profraw
+
+setup-rust-checks:
+	rustup component add rustfmt
+	cargo install cargo-audit
+	rustup component add clippy
+
+checks: setup-rust-checks
+	cargo fmt -- --check
+	cargo audit
+	cargo clippy --all --all-targets --all-features -- -D warnings

--- a/src/server/cache.rs
+++ b/src/server/cache.rs
@@ -306,3 +306,67 @@ async fn tiles_cache_periodic_reporter(cache: &TilesCache, metrics: &Metrics) {
     metrics.count("tiles_cache.count", cache_count);
     metrics.count("tiles_cache.size", cache_size as i64);
 }
+
+#[cfg(test)]
+mod test_tile_cache {
+
+    use super::TilesCache;
+    use crate::server::TILES_CACHE_INITIAL_CAPACITY;
+    use cadence::{NopMetricSink, StatsdClient};
+    use std::{sync::Arc, time::Duration};
+
+    #[actix_web::test]
+    async fn test_spawn_periodic_reporter() {
+        let tiles_cache = TilesCache::new(TILES_CACHE_INITIAL_CAPACITY);
+        let statsd_client = StatsdClient::builder("test", NopMetricSink).build();
+
+        // Just checks that we can spawn the periodic reporter without issues.
+        tiles_cache.spawn_periodic_reporter(Duration::from_secs(1), Arc::new(statsd_client));
+    }
+}
+
+#[cfg(test)]
+mod test_tiles_state {
+    use super::{Tiles, TilesState};
+    use std::time::Duration;
+
+    #[test]
+    fn test_size_populating() {
+        let tiles_state = TilesState::Populating;
+        assert_eq!(tiles_state.size(), 0);
+    }
+
+    #[test]
+    fn test_size_fresh() {
+        let tiles_state = TilesState::Fresh {
+            tiles: Tiles::empty(Duration::from_secs(60), Duration::from_secs(60), true),
+        };
+        assert_eq!(tiles_state.size(), 0);
+    }
+
+    #[test]
+    fn test_size_refreshing() {
+        let tiles_state = TilesState::Refreshing {
+            tiles: Tiles::empty(Duration::from_secs(60), Duration::from_secs(60), true),
+        };
+        assert_eq!(tiles_state.size(), 0);
+    }
+}
+
+#[cfg(test)]
+mod test_tiles_content {
+    use super::TilesContent;
+
+    #[test]
+    fn test_size_json_with_title() {
+        let title = String::from("This is a title");
+        let tile_content = TilesContent::Json(title.clone());
+        assert_eq!(tile_content.size(), title.len());
+    }
+
+    #[test]
+    fn test_size_json_empty_title() {
+        let tile_content = TilesContent::Empty;
+        assert_eq!(tile_content.size(), 0);
+    }
+}


### PR DESCRIPTION
This change does 2 things

1. Adding a Makefile to run checks and create a coverage report
2. Add some tests to a random file (cache)

This is a first step to getting us higher test coverage to prepare Contile for Rapid Release. 