### PR TITLE
feat: Add a metric to measure the tile count of adm response

### DIFF
--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -245,6 +245,12 @@ pub async fn get_tiles(
                 })?
         }
     };
+    metrics.count_with_tags(
+        "tiles.adm.response.tiles_count",
+        response.tiles.len() as i64,
+        Some(tags),
+    );
+    // Keep this counter to facilitate the "zero" ad fill rate monitoring
     if response.tiles.is_empty() {
         warn!("adm::get_tiles empty response {}", adm_url);
         metrics.incr_with_tags("filter.adm.empty_response", Some(tags));

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -210,6 +210,28 @@ impl Tags {
     }
 }
 
+impl Extend<Tags> for Tags {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = Tags>,
+    {
+        for tag in iter {
+            self.extend(tag);
+        }
+    }
+}
+
+impl<'a> Extend<&'a Tags> for Tags {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = &'a Tags>,
+    {
+        for tag in iter {
+            self.extend(tag.clone());
+        }
+    }
+}
+
 impl FromRequest for Tags {
     type Error = Error;
     type Future = Ready<Result<Self, Self::Error>>;

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -915,9 +915,13 @@ async fn metrics() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let prefixes = &["contile.tiles.get:1", "contile.tiles.adm.request:1"];
+    let prefixes = &[
+        "contile.tiles.get:1",
+        "contile.tiles.adm.request:1",
+        "contile.tiles.adm.response.tiles_count:4",
+    ];
     let metrics = find_metrics(&spy, prefixes);
-    assert_eq!(metrics.len(), 2);
+    assert_eq!(metrics.len(), 3);
     let get_metric = &metrics[0];
     assert!(get_metric.contains("ua.form_factor:desktop"));
     assert!(get_metric.contains("ua.os.family:windows"));
@@ -932,7 +936,7 @@ async fn metrics() {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let metrics = find_metrics(&spy, prefixes);
-    assert_eq!(metrics.len(), 2);
+    assert_eq!(metrics.len(), 3);
     let get_metric = &metrics[0];
     assert!(get_metric.contains("ua.form_factor:phone"));
     assert!(get_metric.contains("ua.os.family:ios"));
@@ -1118,6 +1122,7 @@ async fn fallback_on_error() {
         vec![
             "contile.tiles.get:1",
             "contile.tiles.adm.request:1",
+            "contile.tiles.adm.response.tiles_count:4",
             "contile.tiles.get:1",
             "contile.tiles.adm.request:1",
             "contile.tiles.get.error:1"


### PR DESCRIPTION
This closes [DISCO-2346](https://mozilla-hub.atlassian.net/browse/DISCO-2346).

r? @pjenvey for extra eyeballs since this is the first time to use a distribution metric in Contile.

[DISCO-2346]: https://mozilla-hub.atlassian.net/browse/DISCO-2346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ