### PR TITLE
chore: disable sentry's debug-images feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,18 +880,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "findshlibs"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
-dependencies = [
- "cc",
- "lazy_static",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,7 +2157,6 @@ dependencies = [
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
- "sentry-debug-images",
  "sentry-panic",
  "tokio",
  "ureq",
@@ -2212,17 +2199,6 @@ dependencies = [
  "sentry-types",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "sentry-debug-images"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9164d44a2929b1b7670afd7e87552514b70d3ae672ca52884639373d912a3d"
-dependencies = [
- "findshlibs",
- "once_cell",
- "sentry-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rand ="0.8"
 regex = "1"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1"
-sentry = "0.30"
+sentry = { version = "0.30", default-features = false, features = ["backtrace", "contexts", "panic", "transport"] }
 sentry-backtrace = "0.30"
 serde_json = "1"
 scopeguard = "1.1"


### PR DESCRIPTION
which produced errors when sentry ingests events

https://github.com/getsentry/sentry-rust/issues/574

Marking this as a draft pending a response in the above issue. It seems disabling `debug-images` solves this, reproduced locally:

w/ `debug-images`: https://mozilla.sentry.io/issues/4153058160/events/02f583026aa144d6ab237b249a9e294d/?project=6173345

w/out: https://mozilla.sentry.io/issues/4153058160/events/1da82656d0ae4df99ca640a9ed7aea09/?project=6173345