### PR TITLE
[DISCO-2278] Update CircleCI to create and register Contile load test Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,6 +373,7 @@ workflows:
       - load-test-checks
       - docker-image-publish-locust:
           requires:
+            - checks
             - build
             - test
             - contract-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,13 +316,13 @@ jobs:
     steps:
       - checkout:
           path: ~/contile/
-#      - run:
-#          name: Check for main branch
-#          command: |
-#            if ! [ "${CIRCLE_BRANCH}" == "main" ]; then
-#              echo "Skipping remaining steps in this job: load test only run on 'main'."
-#              circleci-agent step halt
-#            fi
+      - run:
+          name: Check for main branch
+          command: |
+            if ! [ "${CIRCLE_BRANCH}" == "main" ]; then
+              echo "Skipping remaining steps in this job: load test only run on 'main'."
+              circleci-agent step halt
+            fi
       - run:
           name: Check for load test directive
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 # These environment variables must be set in CircleCI UI
 #
 # DOCKERHUB_REPO - docker hub repo, format: <username>/<repo>
+# DOCKERHUB_CONTILE_LOAD_TEST_REPO - docker hub repo for performance test, format: <username>/<repo>
 # DOCKER_USER    - login info for docker hub
 # DOCKER_PASS
 #
@@ -13,6 +14,16 @@ parameters:
     default: "1.68"
 
 commands:
+  dockerhub-login:
+    steps:
+      - run:
+          name: Login to Dockerhub
+          command: |
+            if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
+              echo "Skipping Login to DockerHub, credentials unavailable"
+            else
+              echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
+            fi
   setup-rust:
     steps:
       - run:
@@ -131,14 +142,7 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-      - run:
-          name: Login to Dockerhub
-          command: |
-            if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
-              echo "Skipping Login to DockerHub, credentials unavailable"
-            else
-              echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
-            fi
+      - dockerhub-login
       #- save-sccache-cache
       - checkout
       - write-version
@@ -305,6 +309,44 @@ jobs:
           name: mypy
           command: poetry run mypy common locustfiles
 
+  docker-image-publish-locust:
+    docker:
+      - image: cimg/base:2022.08
+    working_directory: "~/contile/test-engineering/load"
+    steps:
+      - checkout:
+          path: ~/contile/
+#      - run:
+#          name: Check for main branch
+#          command: |
+#            if ! [ "${CIRCLE_BRANCH}" == "main" ]; then
+#              echo "Skipping remaining steps in this job: load test only run on 'main'."
+#              circleci-agent step halt
+#            fi
+#      - run:
+#          name: Check for load test directive
+#          command: |
+#            if ! git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\|warn\]'; then
+#              echo "Skipping remaining steps in this job: load test not required."
+#              circleci-agent step halt
+#            fi
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build image
+          command: docker build -t contile-locust .
+      - dockerhub-login
+      - run:
+          name: Push to Docker Hub
+          command: |
+            DOCKER_TAG="${CIRCLE_SHA1}"
+            echo ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:${DOCKER_TAG}
+            docker tag contile-locust ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:${DOCKER_TAG}
+            docker tag contile-locust ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:latest
+            docker images
+            docker push "${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:${DOCKER_TAG}"
+            docker push "${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:latest"
+
 workflows:
   version: 2
   build-deploy:
@@ -329,11 +371,15 @@ workflows:
           - build
           - contract-test-checks
       - load-test-checks
+      - docker-image-publish-locust:
+          requires:
+            - load-test-checks
       - deploy:
           requires:
             - build
             - test
             - contract-tests
+            - docker-image-publish-locust
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,13 +323,13 @@ jobs:
 #              echo "Skipping remaining steps in this job: load test only run on 'main'."
 #              circleci-agent step halt
 #            fi
-#      - run:
-#          name: Check for load test directive
-#          command: |
-#            if ! git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\|warn\]'; then
-#              echo "Skipping remaining steps in this job: load test not required."
-#              circleci-agent step halt
-#            fi
+      - run:
+          name: Check for load test directive
+          command: |
+            if ! git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\|warn\]'; then
+              echo "Skipping remaining steps in this job: load test not required."
+              circleci-agent step halt
+            fi
       - setup_remote_docker:
           docker_layer_caching: true
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,12 +373,12 @@ workflows:
       - load-test-checks
       - docker-image-publish-locust:
           requires:
-            - load-test-checks
-      - deploy:
-          requires:
             - build
             - test
             - contract-tests
+            - load-test-checks
+      - deploy:
+          requires:
             - docker-image-publish-locust
           filters:
             tags:


### PR DESCRIPTION
## References

JIRA: [DISCO-2278](https://mozilla-hub.atlassian.net/browse/DISCO-2278)
GitHub: #523 

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Add the docker-image-publish-locust job to CI, which automates the encapsulation of the load test solution in a Docker image and registers it on Docker Hub.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] Functional and performance test coverage has been expanded and maintained 
- [x] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2278]: https://mozilla-hub.atlassian.net/browse/DISCO-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ