### PR TITLE
chore: move disabling of debug-images into code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,6 +2169,7 @@ dependencies = [
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
+ "sentry-debug-images",
  "sentry-panic",
  "tokio",
  "ureq",
@@ -2199,6 +2212,17 @@ dependencies = [
  "sentry-types",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9164d44a2929b1b7670afd7e87552514b70d3ae672ca52884639373d912a3d"
+dependencies = [
+ "findshlibs",
+ "once_cell",
+ "sentry-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rand ="0.8"
 regex = "1"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1"
-sentry = { version = "0.30", default-features = false, features = ["backtrace", "contexts", "panic", "transport"] }
+sentry = "0.30"
 sentry-backtrace = "0.30"
 serde_json = "1"
 scopeguard = "1.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,13 +47,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Arc::new(sentry::transports::CurlHttpTransport::new(&options))
             as Arc<dyn sentry::internals::Transport>
     };
-    */
-    let _sentry = sentry::init(sentry::ClientOptions {
+     */
+    // Disable debug-images: it conflicts w/ our debug = 1 rustc build option:
+    // https://github.com/getsentry/sentry-rust/issues/574
+    let mut opts = sentry::apply_defaults(sentry::ClientOptions {
         // Note: set "debug: true," to diagnose sentry issues
         // transport: Some(Arc::new(curl_transport_factory)),
         release: sentry::release_name!(),
         ..sentry::ClientOptions::default()
     });
+    opts.integrations.retain(|i| i.name() != "debug-images");
+    opts.default_integrations = false;
+    let _sentry = sentry::init(opts);
 
     debug!("Starting up...");
 


### PR DESCRIPTION
## References

GitHub: [sentry-rust#574](https://github.com/getsentry/sentry-rust/issues/574)

## Description

so we can keep the crate's default-features in Cargo.toml

(follow up to 976da76a, thanks JR)



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [ ] Functional and performance test coverage has been expanded and maintained 
- [ ] Documentation has been updated
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title
