### PR TITLE
[DISCO-2277] Deploy stage and production images to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,8 @@ jobs:
 
   docker-image-publish-stage:
     # The commit tag signals deployment and load test instructions to Jenkins by
-    # modifying the Docker image tag name. The convention looks as follows:
+    # modifying the Docker image tag name. Pushing a new Docker image to the Docker Hub registry
+    # triggers a webhook that starts the Jenkins deployment workflow. The convention looks as follows:
     #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$
     docker:
       - image: docker:18.02.0-ce
@@ -213,23 +214,19 @@ jobs:
       - restore_cache:
           key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
+          name: Check for main branch
+          command: |
+            if ! [ "${CIRCLE_BRANCH}" == "main" ]; then
+              echo "Skipping remaining steps in this job: deployments only run on 'main'."
+              circleci-agent step halt
+            fi
+      - run:
           name: Restore Docker image cache
           command: docker load -i /home/circleci/cache/docker.tar
+      - dockerhub-login
       - run:
           name: Deploy to Dockerhub
           command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              STAGE_DOCKER_TAG="${CIRCLE_SHA1}"
-            fi
-
-            if echo "${CIRCLE_BRANCH}" | grep '^feature\..*' > /dev/null; then
-              STAGE_DOCKER_TAG="${CIRCLE_BRANCH}"
-            fi
-
-            if [ -n "${CIRCLE_TAG}" ]; then
-              STAGE_DOCKER_TAG="$CIRCLE_TAG"
-            fi
-
             if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
               echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
               STAGE_DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
@@ -240,19 +237,12 @@ jobs:
               STAGE_DOCKER_TAG="stage-${CIRCLE_SHA1}"
             fi
 
-            if [ -n "${STAGE_DOCKER_TAG}" ]; then
-              echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-              echo ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
-              docker tag app:build ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
-              docker images
-              docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
-            else
-              echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
-            fi
+            echo ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
+            docker tag app:build ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
+            docker images
+            docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
 
   docker-image-publish-prod:
-    # Pushing a new production Docker image to the Docker Hub registry triggers a
-    # webhook that starts the Jenkins deployment workflow.
     docker:
       - image: docker:18.02.0-ce
         auth:
@@ -263,43 +253,26 @@ jobs:
       - restore_cache:
           key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
+          name: Check for main branch
+          command: |
+            if ! [ "${CIRCLE_BRANCH}" == "main" ]; then
+              echo "Skipping remaining steps in this job: deployments only run on 'main'."
+              circleci-agent step halt
+            fi
+      - run:
           name: Restore Docker image cache
           command: docker load -i /home/circleci/cache/docker.tar
+      - dockerhub-login
       - run:
           name: Deploy to Dockerhub
           command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              PROD_DOCKER_TAG="${CIRCLE_SHA1}"
-            fi
-
-            if echo "${CIRCLE_BRANCH}" | grep '^feature\..*' > /dev/null; then
-              PROD_DOCKER_TAG="${CIRCLE_BRANCH}"
-            fi
-
-            if [ -n "${CIRCLE_TAG}" ]; then
-              PROD_DOCKER_TAG="$CIRCLE_TAG"
-            fi
-
-            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
-              echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
-              PROD_DOCKER_TAG="prod-loadtest-warn-${CIRCLE_SHA1}"
-            elif git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
-              echo "Load test requested. Deployment workflow for prod will abort if load test fails."
-              PROD_DOCKER_TAG="prod-loadtest-abort-${CIRCLE_SHA1}"
-            else
-              PROD_DOCKER_TAG="prod-${CIRCLE_SHA1}"
-            fi
-
-            if [ -n "${PROD_DOCKER_TAG}" ]; then
-              echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-              echo ${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}
-              docker tag app:build ${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}
-              docker images
-              docker push "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
-              docker push "${DOCKERHUB_REPO}:latest"
-            else
-              echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
-            fi
+            PROD_DOCKER_TAG="prod-${CIRCLE_SHA1}"
+            echo "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
+            docker tag app:build "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
+            docker tag app:build "${DOCKERHUB_REPO}:latest"
+            docker images
+            docker push "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
+            docker push "${DOCKERHUB_REPO}:latest"
 
   contract-test-checks:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,56 @@ jobs:
               echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
             fi
 
+  docker-image-publish-prod:
+    # Pushing a new production Docker image to the Docker Hub registry triggers a
+    # webhook that starts the Jenkins deployment workflow.
+    docker:
+      - image: docker:18.02.0-ce
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    steps:
+      - setup_remote_docker
+      - restore_cache:
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Restore Docker image cache
+          command: docker load -i /home/circleci/cache/docker.tar
+      - run:
+          name: Deploy to Dockerhub
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+              PROD_DOCKER_TAG="${CIRCLE_SHA1}"
+            fi
+
+            if echo "${CIRCLE_BRANCH}" | grep '^feature\..*' > /dev/null; then
+              PROD_DOCKER_TAG="${CIRCLE_BRANCH}"
+            fi
+
+            if [ -n "${CIRCLE_TAG}" ]; then
+              PROD_DOCKER_TAG="$CIRCLE_TAG"
+            fi
+
+            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
+              echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
+              PROD_DOCKER_TAG="prod-loadtest-warn-${CIRCLE_SHA1}"
+            elif git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
+              echo "Load test requested. Deployment workflow for prod will abort if load test fails."
+              PROD_DOCKER_TAG="prod-loadtest-abort-${CIRCLE_SHA1}"
+            else
+              PROD_DOCKER_TAG="prod-${CIRCLE_SHA1}"
+            fi
+
+            if [ -n "${PROD_DOCKER_TAG}" ]; then
+              echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+              echo ${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}
+              docker tag app:build ${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}
+              docker images
+              docker push "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
+            else
+              echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
+            fi
+
   contract-test-checks:
     docker:
       - image: cimg/python:3.11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,8 +200,9 @@ jobs:
             fi
 
   docker-image-publish-stage:
-    # Pushing a new production Docker image to the Docker Hub registry triggers a
-    # webhook that starts the Jenkins deployment workflow.
+    # The commit tag signals deployment and load test instructions to Jenkins by
+    # modifying the Docker image tag name. The convention looks as follows:
+    #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$
     docker:
       - image: docker:18.02.0-ce
         auth:
@@ -295,6 +296,7 @@ jobs:
               docker tag app:build ${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}
               docker images
               docker push "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
+              docker push "${DOCKERHUB_REPO}:latest"
             else
               echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
             fi
@@ -438,9 +440,6 @@ jobs:
       - dockerhub-login
       - run:
           name: Push to Docker Hub
-          # The commit tag signals deployment and load test instructions to Jenkins by
-          # modifying the Docker image tag name. The convention looks as follows:
-          #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$
           command: |
             DOCKER_TAG="${CIRCLE_SHA1}"
             echo ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:${DOCKER_TAG}
@@ -481,9 +480,15 @@ workflows:
             - test
             - contract-tests
             - load-test-checks
-      - deploy:
+      - docker-image-publish-stage:
           requires:
             - docker-image-publish-locust
+          filters:
+            tags:
+              only: /.*/
+      - docker-image-publish-prod:
+          requires:
+            - docker-image-publish-stage
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,44 +161,6 @@ jobs:
           paths:
             - /home/circleci/cache
 
-  deploy:
-    docker:
-      - image: docker:18.02.0-ce
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-    steps:
-      - setup_remote_docker
-      - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-      - run:
-          name: Restore Docker image cache
-          command: docker load -i /home/circleci/cache/docker.tar
-      - run:
-          name: Deploy to Dockerhub
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              DOCKER_TAG="${CIRCLE_SHA1}"
-            fi
-
-            if echo "${CIRCLE_BRANCH}" | grep '^feature\..*' > /dev/null; then
-              DOCKER_TAG="${CIRCLE_BRANCH}"
-            fi
-
-            if [ -n "${CIRCLE_TAG}" ]; then
-              DOCKER_TAG="$CIRCLE_TAG"
-            fi
-
-            if [ -n "${DOCKER_TAG}" ]; then
-              echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-              echo ${DOCKERHUB_REPO}:${DOCKER_TAG}
-              docker tag app:build ${DOCKERHUB_REPO}:${DOCKER_TAG}
-              docker images
-              docker push "${DOCKERHUB_REPO}:${DOCKER_TAG}"
-            else
-              echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
-            fi
-
   docker-image-publish-stage:
     # The commit tag signals deployment and load test instructions to Jenkins by
     # modifying the Docker image tag name. Pushing a new Docker image to the Docker Hub registry
@@ -210,9 +172,6 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
-      - setup_remote_docker
-      - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Check for main branch
           command: |
@@ -220,6 +179,9 @@ jobs:
               echo "Skipping remaining steps in this job: deployments only run on 'main'."
               circleci-agent step halt
             fi
+      - setup_remote_docker
+      - restore_cache:
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Restore Docker image cache
           command: docker load -i /home/circleci/cache/docker.tar
@@ -238,9 +200,9 @@ jobs:
             fi
 
             echo ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
-            docker tag app:build ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
-            docker images
-            docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
+            # docker tag app:build ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
+            # docker images
+            # docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
 
   docker-image-publish-prod:
     docker:
@@ -256,7 +218,7 @@ jobs:
           name: Check for main branch
           command: |
             if ! [ "${CIRCLE_BRANCH}" == "main" ]; then
-              echo "Skipping remaining steps in this job: deployments only run on 'main'."
+              echo "Skipping remaining steps in this job: load test only run on 'main'."
               circleci-agent step halt
             fi
       - run:
@@ -456,12 +418,6 @@ workflows:
       - docker-image-publish-stage:
           requires:
             - docker-image-publish-locust
-          filters:
-            tags:
-              only: /.*/
-      - docker-image-publish-prod:
-          requires:
-            - docker-image-publish-stage
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,15 @@ jobs:
           # modifying the Docker image tag name. The convention looks as follows:
           #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$
           command: |
-            DOCKER_TAG="${CIRCLE_SHA1}"
+            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
+              echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
+              DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
+            elif git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
+              echo "Load test requested. Deployment workflow for prod will abort if load test fails."
+              DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
+            else
+              DOCKER_TAG="stage-${CIRCLE_SHA1}"
+            fi
             echo ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:${DOCKER_TAG}
             docker tag contile-locust ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:${DOCKER_TAG}
             docker tag contile-locust ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,56 @@ jobs:
               echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
             fi
 
+  docker-image-publish-stage:
+    # Pushing a new production Docker image to the Docker Hub registry triggers a
+    # webhook that starts the Jenkins deployment workflow.
+    docker:
+      - image: docker:18.02.0-ce
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    steps:
+      - setup_remote_docker
+      - restore_cache:
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Restore Docker image cache
+          command: docker load -i /home/circleci/cache/docker.tar
+      - run:
+          name: Deploy to Dockerhub
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+              STAGE_DOCKER_TAG="${CIRCLE_SHA1}"
+            fi
+
+            if echo "${CIRCLE_BRANCH}" | grep '^feature\..*' > /dev/null; then
+              STAGE_DOCKER_TAG="${CIRCLE_BRANCH}"
+            fi
+
+            if [ -n "${CIRCLE_TAG}" ]; then
+              STAGE_DOCKER_TAG="$CIRCLE_TAG"
+            fi
+
+            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
+              echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
+              STAGE_DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
+            elif git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
+              echo "Load test requested. Deployment workflow for prod will abort if load test fails."
+              STAGE_DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
+            else
+              STAGE_DOCKER_TAG="stage-${CIRCLE_SHA1}"
+            fi
+
+            if [ -n "${STAGE_DOCKER_TAG}" ]; then
+              echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+              echo ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
+              docker tag app:build ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
+              docker images
+              docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
+            else
+              echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
+            fi
+
   contract-test-checks:
     docker:
       - image: cimg/python:3.11
@@ -342,15 +392,7 @@ jobs:
           # modifying the Docker image tag name. The convention looks as follows:
           #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$
           command: |
-            if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
-              echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
-              DOCKER_TAG="stage-loadtest-warn-${CIRCLE_SHA1}"
-            elif git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\]'; then
-              echo "Load test requested. Deployment workflow for prod will abort if load test fails."
-              DOCKER_TAG="stage-loadtest-abort-${CIRCLE_SHA1}"
-            else
-              DOCKER_TAG="stage-${CIRCLE_SHA1}"
-            fi
+            DOCKER_TAG="${CIRCLE_SHA1}"
             echo ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:${DOCKER_TAG}
             docker tag contile-locust ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:${DOCKER_TAG}
             docker tag contile-locust ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,7 @@ jobs:
           name: Check for main branch
           command: |
             if ! [ "${CIRCLE_BRANCH}" == "main" ]; then
-              echo "Skipping remaining steps in this job: load test only run on 'main'."
+              echo "Skipping remaining steps in this job: deployments only run on 'main'."
               circleci-agent step halt
             fi
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,9 +136,9 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         environment:
-            RUST_BACKTRACE: 1
-            # XXX: begin_test_transaction doesn't play nice over threaded tests
-            RUST_TEST_THREADS: 1
+          RUST_BACKTRACE: 1
+          # XXX: begin_test_transaction doesn't play nice over threaded tests
+          RUST_TEST_THREADS: 1
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -234,55 +234,55 @@ jobs:
       - restore_cache:
           key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
-         name: Restore Docker image cache
-         command: docker load -i /home/circleci/cache/docker.tar
+          name: Restore Docker image cache
+          command: docker load -i /home/circleci/cache/docker.tar
       - run:
-         name: Log in to the default Docker registry
-         command: |
-           echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          name: Log in to the default Docker registry
+          command: |
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
       - run:
-         name: Build client and partner images
-         command: |
-           docker-compose --version
-           docker-compose \
-            -f test-engineering/contract-tests/docker-compose.yml \
-            build client partner
+          name: Build client and partner images
+          command: |
+            docker-compose --version
+            docker-compose \
+             -f test-engineering/contract-tests/docker-compose.yml \
+             build client partner
       - run:
-         name: Run contract tests
-         command: |
-           docker-compose \
-            -f test-engineering/contract-tests/docker-compose.yml \
-            up --abort-on-container-exit --force-recreate
+          name: Run contract tests
+          command: |
+            docker-compose \
+             -f test-engineering/contract-tests/docker-compose.yml \
+             up --abort-on-container-exit --force-recreate
       - run:
           name: Run "tiles cache" contract tests
           command: |
-           docker-compose \
-            -f test-engineering/contract-tests/docker-compose.yml \
-            -f test-engineering/contract-tests/docker-compose.tiles_cache.yml \
-            up --abort-on-container-exit --force-recreate
+            docker-compose \
+             -f test-engineering/contract-tests/docker-compose.yml \
+             -f test-engineering/contract-tests/docker-compose.tiles_cache.yml \
+             up --abort-on-container-exit --force-recreate
       - run:
-         name: Run "204" contract tests
-         command: |
-           docker-compose \
-            -f test-engineering/contract-tests/docker-compose.yml \
-            -f test-engineering/contract-tests/docker-compose.204.yml \
-            up --abort-on-container-exit --force-recreate
+          name: Run "204" contract tests
+          command: |
+            docker-compose \
+             -f test-engineering/contract-tests/docker-compose.yml \
+             -f test-engineering/contract-tests/docker-compose.204.yml \
+             up --abort-on-container-exit --force-recreate
       - run:
-         name: Run "init_error" contract tests
-         command: |
-           set +e # We need this so that the run doesn't exit after docker-compose
-           docker-compose \
-            -f test-engineering/contract-tests/docker-compose.yml \
-            -f test-engineering/contract-tests/docker-compose.init_error.yml \
-            up --abort-on-container-exit --exit-code contile --force-recreate
-           contile_exit_code=$?
-           if [ "${contile_exit_code}" -eq 0 ]; then
-            echo "Expected non-zero exit_code from Contile service"
-            exit 1
-           else
-            echo "Contile service exit_code: ${contile_exit_code}"
-            exit 0
-           fi
+          name: Run "init_error" contract tests
+          command: |
+            set +e # We need this so that the run doesn't exit after docker-compose
+            docker-compose \
+             -f test-engineering/contract-tests/docker-compose.yml \
+             -f test-engineering/contract-tests/docker-compose.init_error.yml \
+             up --abort-on-container-exit --exit-code contile --force-recreate
+            contile_exit_code=$?
+            if [ "${contile_exit_code}" -eq 0 ]; then
+             echo "Expected non-zero exit_code from Contile service"
+             exit 1
+            else
+             echo "Contile service exit_code: ${contile_exit_code}"
+             exit 0
+            fi
 
   load-test-checks:
     docker:
@@ -338,6 +338,9 @@ jobs:
       - dockerhub-login
       - run:
           name: Push to Docker Hub
+          # The commit tag signals deployment and load test instructions to Jenkins by
+          # modifying the Docker image tag name. The convention looks as follows:
+          #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$
           command: |
             DOCKER_TAG="${CIRCLE_SHA1}"
             echo ${DOCKERHUB_CONTILE_LOAD_TEST_REPO}:${DOCKER_TAG}
@@ -368,8 +371,8 @@ workflows:
       - contract-test-checks
       - contract-tests:
           requires:
-          - build
-          - contract-test-checks
+            - build
+            - contract-test-checks
       - load-test-checks
       - docker-image-publish-locust:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,9 +200,9 @@ jobs:
             fi
 
             echo ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
-            # docker tag app:build ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
-            # docker images
-            # docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
+            docker tag app:build ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
+            docker images
+            docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
 
   docker-image-publish-prod:
     docker:
@@ -211,9 +211,6 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
-      - setup_remote_docker
-      - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Check for main branch
           command: |
@@ -221,6 +218,9 @@ jobs:
               echo "Skipping remaining steps in this job: load test only run on 'main'."
               circleci-agent step halt
             fi
+      - setup_remote_docker
+      - restore_cache:
+          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Restore Docker image cache
           command: docker load -i /home/circleci/cache/docker.tar
@@ -411,13 +411,18 @@ workflows:
       - docker-image-publish-locust:
           requires:
             - checks
-            - build
             - test
             - contract-tests
             - load-test-checks
       - docker-image-publish-stage:
           requires:
             - docker-image-publish-locust
+          filters:
+            tags:
+              only: /.*/
+      - docker-image-publish-prod:
+          requires:
+            - docker-image-publish-stage
           filters:
             tags:
               only: /.*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,9 @@ Before submitting a PR:
   pass and the code has been reviewed.
 - Your patch should include new tests that cover your changes. It is your and
   your reviewer's responsibility to ensure your patch includes adequate tests.
+- If making changes that may impact performance, it is recommended to execute a load test. Please see [Load Testing Opt-In [load test: (abort|warn)]](test-engineering/load/README.md#opt-in-execution-in-staging-and-production) documentation for more information.
+- For more information on understanding the release process, please see relevant information contained in the [README.md](README.md#releasing-to-production)
+documentation.
 
 When submitting a PR:
 - You agree to license your code under the project's open source license

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,6 @@ _Put an `x` in the boxes that apply_
 
 - [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
 - [ ] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
-- [ ] Functional and performance test coverage has been expanded and maintained 
+- [ ] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
 - [ ] Documentation has been updated
 - [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See the dedicated [contract-tests README](test-engineering/contract-tests/README
 #### Load Tests
 Load testing can be run locally or as a part of the deployment process. Please see the [Contile Load (Locust) Tests](test-engineering/load/README.md) for detailed instructions. Local execution does not require any labeling in commit messages. 
 
-For deployment, you have to add a label to the message of the commit that you wish to deploy in the form of: `[load test: (abort|warn)]`. In most cases this will be the merge commit created by merging a GitHub pull request. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on this convention, please see the relevant documentation: [Load Test Readme](test-engineering/load/README.md#opt-in-execution-in-staging-and-production).
+For deployment, you have to add a label to the message of the commit that you wish to deploy in the form of: `[load test: (abort|warn)]`. In most cases this will be the merge commit created by merging a GitHub pull request. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on this convention, please see the relevant documentation: [Load Test Readme](test-engineering/load/README.md#opt-in-execution-in-staging-and-production ).
 
 #### Releasing to Production
 Developers with write access to the Contile repository can initiate a deployment to production after a Pull-Request on the Contile GitHub repository is merged to the `main` branch.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ CONTILE_ADM_ENDPOINT_URL={Your ADM endpoint} \
 Please note that the `{}` indicate a variable replacement and should not be included, for example, a real environmet variable would look like: `CONTILE_ADM_ENDPOINT_URL=https://example.com/`
 
 ### Testing
-#### Unit tests
+#### Unit Tests
 
 To run Contile's unit tests, run
 
@@ -51,11 +51,21 @@ GOOGLE_APPLICATION_CREDENTIALS={path to your credential.json file} \
     cargo test
 ```
 
-#### Contract tests
+#### Contract Tests
 
 Contract tests are currently run using Docker images. This is so that they can be run as
 part of our automated continuous integration (CI) testing. 
 See the dedicated [contract-tests README](test-engineering/contract-tests/README.md) for details.
+
+#### Load Tests
+Load testing can be run locally or as a part of the deployment process. Please see the [Contile Load (Locust) Tests](test-engineering/load/README.md) for detailed instructions. Local execution does not require any labeling in commit messages. 
+
+For deployment, you have to add a label to the message of the commit that you wish to deploy in the form of: `[load test: (abort|warn)]`. In most cases this will be the merge commit created by merging a GitHub pull request. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on this convention, please see the relevant documentation: [Load Test Readme](test-engineering/load/README.md#opt-in-execution-in-staging-and-production).
+
+#### Releasing to Production
+Developers with write access to the Contile repository can initiate a deployment to production after a Pull-Request on the Contile GitHub repository is merged to the `main` branch.
+
+While any developer with write access can trigger the deployment to production, the _expectation_ is that individual(s) who authored and merged the Pull-Request should do so, as they are the ones most familiar with their changes and who can tell, by looking at the data, if anything looks anomalous.
 
 ## Why "Contile"?
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See the dedicated [contract-tests README](test-engineering/contract-tests/README
 #### Load Tests
 Load testing can be run locally or as a part of the deployment process. Please see the [Contile Load (Locust) Tests](test-engineering/load/README.md) for detailed instructions. Local execution does not require any labeling in commit messages. 
 
-For deployment, you have to add a label to the message of the commit that you wish to deploy in the form of: `[load test: (abort|warn)]`. In most cases this will be the merge commit created by merging a GitHub pull request. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on this convention, please see the relevant documentation: [Load Test Readme](test-engineering/load/README.md#opt-in-execution-in-staging-and-production ).
+For deployment, you have to add a label to the message of the commit that you wish to deploy in the form of: `[load test: (abort|warn)]`. In most cases this will be the merge commit created by merging a GitHub pull request. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on this convention, please see the relevant documentation: [Load Test Readme](test-engineering/load/README.md#opt-in-execution-in-staging-and-production).
 
 #### Releasing to Production
 Developers with write access to the Contile repository can initiate a deployment to production after a Pull-Request on the Contile GitHub repository is merged to the `main` branch.

--- a/test-engineering/load/README.md
+++ b/test-engineering/load/README.md
@@ -45,6 +45,23 @@ poetry run flake8 common locustfiles
 poetry run mypy common locustfiles
 ```
 
+## Opt-In Execution in Staging (and Production)
+
+To automatically kick off load testing in staging along with your pull request commit, you have to include
+a label in your git commit. This must be the merge commit on the `main` branch, since only the most recent commit is checked for the label. This label is in the form of: `[load test: (abort|warn)]`. Take careful note
+of correct syntax and spacing within the label. There are two options for load tests, being `abort` and `warn`.
+
+The `abort` label will prevent a `prod` deployment should the load test fail.
+Ex. `feat: Add feature ABC [load test: abort]`.
+
+The `warn` label will output a Slack warning should the load test fail, but still allow for `prod` deployment.
+Ex. `feat: Add feature XYZ [load test: warn]`.
+
+The commit tag signals load test instructions to Jenkins by modifying the Docker image tag. The Jenkins deployment workflow first deploys to `stage` and then runs load tests if requested. The Docker image tag passed to Jenkins appears as follows:
+`^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$`.
+
+The `docker-image-publish-stage` and `docker-image-publish-prod` jobs in [.circleci/config.yml](/.circleci/config.yml) define this process so you can view the steps there for more clarity.
+
 ## Local Execution
 
 Follow the steps bellow to execute the load tests locally:


### PR DESCRIPTION
## References

JIRA: [DISCO-2277](https://mozilla-hub.atlassian.net/browse/DISCO-2277)
GitHub: [#TODO](https://github.com/mozilla-services/contile/issues/TODO)

## Description
In order to facilitate stage and production deployments, as well as to allow contributors to opt-in to load testing on the deployment pipeline, create distinctive Docker Hub publication jobs in the CircleCI workflow. 

Enable signalization to Jenkins via Docker tag assignment, using the following convention:

`^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$`

**Example Docker image tag name:**

<img width="464" alt="image-20230228-152205" src="https://user-images.githubusercontent.com/35045299/236927749-c7701dda-b55d-48f8-b1fe-03bf02df18b4.png">


The load test signal is established using text in a git commit. The text should take the form [load test: (abort|warn)]. 

The abort text will prevent a prod deployment should the load test fail. 

The warn text will output a Slack warning should the load test fail, but still allow for the production deployment.

**Example commit text:**

feat: Add feature ABC [load test: warn]

feat: Add feature XYZ [load test: abort]

**Resources**

Example: [Merino CI workflows](https://github.com/mozilla-services/merino-py/blob/main/.circleci/config.yml)

Acceptance Criteria

SRE is informed of this modification and deployment is coordinated

Replace the existing deploy job with two jobs: docker-image-publish-stage and docker-image-publish-prod

The docker-image-publish-stage job is responsible for assigning the stage Docker tag and pushing the image to Docker Hub. 

 Assignment of the stage tag includes parsing for the load test commit message. 

The docker-image-publish-prod job is responsible for assigning the prod and latest Docker tags and pushing the images to Docker Hub.

The   guideline, the[ PULL_REQUEST_TEMPLATE.md](https://github.com/mozilla-services/contile/blob/main/PULL_REQUEST_TEMPLATE.md) and any other relevant documentation is updated



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [ ] Functional and performance test coverage has been expanded and maintained 
- [x] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2277]: https://mozilla-hub.atlassian.net/browse/DISCO-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ