### PR TITLE
[DISCO-2333] Split up the CircleCI workflow for PR and `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,13 +175,6 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
-      - run:
-          name: Check for main branch
-          command: |
-            if ! [ "${CIRCLE_BRANCH}" == "main" ]; then
-              echo "Skipping remaining steps in this job: deployments only run on 'main'."
-              circleci-agent step halt
-            fi
       - setup_remote_docker
       - restore_cache:
           key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
@@ -214,13 +207,6 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
-      - run:
-          name: Check for main branch
-          command: |
-            if ! [ "${CIRCLE_BRANCH}" == "main" ]; then
-              echo "Skipping remaining steps in this job: deployments only run on 'main'."
-              circleci-agent step halt
-            fi
       - setup_remote_docker
       - restore_cache:
           key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
@@ -357,13 +343,6 @@ jobs:
       - checkout:
           path: ~/contile/
       - run:
-          name: Check for main branch
-          command: |
-            if ! [ "${CIRCLE_BRANCH}" == "main" ]; then
-              echo "Skipping remaining steps in this job: load test only run on 'main'."
-              circleci-agent step halt
-            fi
-      - run:
           name: Check for load test directive
           command: |
             if ! git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: abort\|warn\]'; then
@@ -389,43 +368,61 @@ jobs:
 
 workflows:
   version: 2
-  build-deploy:
+  pr-workflow:
     jobs:
-      - checks:
+      - checks: &pr-filters
           filters:
-            tags:
-              only: /.*/
+            branches:
+              ignore: main
       - build:
-          filters:
-            tags:
-              only: /.*/
+          <<: *pr-filters
       - test:
-          filters:
-            tags:
-              only: /.*/
+          <<: *pr-filters
           requires:
             - build
-      - contract-test-checks
+      - contract-test-checks:
+          <<: *pr-filters
       - contract-tests:
+          <<: *pr-filters
+          requires:
+          - build
+          - contract-test-checks
+      - load-test-checks:
+          <<: *pr-filters
+
+  main-workflow:
+    jobs:
+      - checks: &main-filters
+          filters:
+            branches:
+              only: main
+      - build:
+          <<: *main-filters
+      - test:
+          <<: *main-filters
+          requires:
+            - build
+      - contract-test-checks:
+          <<: *main-filters
+      - contract-tests:
+          <<: *main-filters
           requires:
             - build
             - contract-test-checks
-      - load-test-checks
+      - load-test-checks:
+          <<: *main-filters
       - docker-image-publish-locust:
+          <<: *main-filters
           requires:
             - checks
             - test
             - contract-tests
             - load-test-checks
       - docker-image-publish-stage:
+          <<: *main-filters
           requires:
             - docker-image-publish-locust
-          filters:
-            tags:
-              only: /.*/
       - docker-image-publish-prod:
+          <<: *main-filters
           requires:
             - docker-image-publish-stage
-          filters:
-            tags:
-              only: /.*/


### PR DESCRIPTION
## References

JIRA: [DISCO-2333](https://mozilla-hub.atlassian.net/browse/DISCO-2333)

## Description
This change runs 2 different workflows for whether the code goes to `main` or if the code runs via `pr`. We don't want to publish images to DockerHub for CI runs on the PR.

I'll need to also update the branch protection rules to use the new workflow name after I get approval:

![Screenshot 2023-05-10 at 13 28 08](https://github.com/mozilla-services/contile/assets/829597/ed82a04f-b8f6-4908-84bd-bcb8cba210bc)



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [ ] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2333]: https://mozilla-hub.atlassian.net/browse/DISCO-2333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ