### PR TITLE
Remove dependency on the `build` step to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,30 +73,18 @@ commands:
   run-tests:
     steps:
       - run:
-          name: cargo test
-          command: cargo test --all --verbose
-
-  report-test-results:
-    steps:
-      - run:
           name: Install cargo2junit
           command: cargo install cargo2junit
-      - run:
-          name: Generate test results report in JUnit XML format
-          command: |
-            cargo test -- \
-            -Z unstable-options --format json --report-time | cargo2junit > results.xml
-      - store_test_results:
-          path: results.xml
-
-  run-code-coverage:
-    steps:
       - run:
           name: Install cargo-llvm-cov
           command: cargo install cargo-llvm-cov
       - run:
-          name: Test coverage check (Minimum 54%)
-          command: cargo llvm-cov --html --fail-under-lines 54
+          name: Run and report tests and coverage (Minimum 54%)
+          command: |
+            cargo llvm-cov --no-report test -- -Z unstable-options --format json --report-time | cargo2junit > results.xml && \
+            cargo llvm-cov report --fail-under-lines 54 --html
+      - store_test_results:
+          path: results.xml
       - store_artifacts:
           path: target/llvm-cov/html # Default location
           destination: llvm-cov/html
@@ -153,8 +141,6 @@ jobs:
       - setup-rust
       - cargo-build
       - run-tests
-      - report-test-results
-      - run-code-coverage
 
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,8 +405,6 @@ workflows:
           <<: *pr-filters
       - test:
           <<: *pr-filters
-          requires:
-            - build
       - contract-test-checks:
           <<: *pr-filters
       - contract-tests:
@@ -427,8 +425,6 @@ workflows:
           <<: *main-filters
       - test:
           <<: *main-filters
-          requires:
-            - build
       - contract-test-checks:
           <<: *main-filters
       - contract-tests:


### PR DESCRIPTION
## Description
We want to see if this makes the build slightly faster. I also modified the test run to _not_ run all the tests 3 times. 

relates to DISCO-2392



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [x] Documentation has been updated
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title
