### PR TITLE
[DISCO-2280] Add 'check-for-deployment' and 'unhold-to-deploy' jobs to the Contile CI main-workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,31 +107,6 @@ commands:
           path: target/llvm-cov/html # Default location
           destination: llvm-cov/html
 
-  report-test-results:
-    steps:
-      - run:
-          name: Install cargo2junit
-          command: cargo install cargo2junit
-      - run:
-          name: Generate test results report in JUnit XML format
-          command: |
-            cargo test -- \
-            -Z unstable-options --format json --report-time | cargo2junit > results.xml
-      - store_test_results:
-          path: results.xml
-
-  run-code-coverage:
-    steps:
-      - run:
-          name: Install cargo-llvm-cov
-          command: cargo install cargo-llvm-cov
-      - run:
-          name: Test coverage check (Minimum 54%)
-          command: cargo llvm-cov --html --fail-under-lines 54
-      - store_artifacts:
-          path: target/llvm-cov/html # Default location
-          destination: llvm-cov/html
-
   setup-sccache:
     steps:
       - run:
@@ -175,6 +150,7 @@ jobs:
     steps:
       - checkout
       - skip-if-do-not-deploy
+
   test:
     docker:
       - image: cimg/rust:<< pipeline.parameters.rust-version >>
@@ -190,8 +166,6 @@ jobs:
       - setup-rust
       - cargo-build
       - run-tests
-      - report-test-results
-      - run-code-coverage
 
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,24 @@ commands:
             "$CIRCLE_PROJECT_USERNAME" \
             "$CIRCLE_PROJECT_REPONAME" \
             "$CIRCLE_BUILD_URL" > version.json
+  skip-if-do-not-deploy:
+    steps:
+      - run:
+          name: Check if deployment is disallowed
+          # This relies on the [do not deploy] text to be available in the
+          # merge commit when merging the PR to 'main'.
+          command: |
+            if git log -1 "$CIRCLE_SHA1" | grep -q '\[do not deploy\]'; then
+                echo "Skipping remaining steps in this job: deployment was disabled for this commit."
+                circleci-agent step halt
+
+                # No need to deploy, just cancel the rest of jobs of the workflow.
+                # See API detail: https://circleci.com/docs/api/v2/index.html#operation/cancelWorkflow
+
+                curl -X POST https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel \
+                -H 'Accept: application/json' \
+                -H "Circle-Token: ${SKIP_DEPLOY_API_TOKEN}"
+            fi
 
   run-tests:
     steps:
@@ -85,6 +103,31 @@ commands:
             cargo llvm-cov report --fail-under-lines 54 --html
       - store_test_results:
           path: results.xml
+      - store_artifacts:
+          path: target/llvm-cov/html # Default location
+          destination: llvm-cov/html
+
+  report-test-results:
+    steps:
+      - run:
+          name: Install cargo2junit
+          command: cargo install cargo2junit
+      - run:
+          name: Generate test results report in JUnit XML format
+          command: |
+            cargo test -- \
+            -Z unstable-options --format json --report-time | cargo2junit > results.xml
+      - store_test_results:
+          path: results.xml
+
+  run-code-coverage:
+    steps:
+      - run:
+          name: Install cargo-llvm-cov
+          command: cargo install cargo-llvm-cov
+      - run:
+          name: Test coverage check (Minimum 54%)
+          command: cargo llvm-cov --html --fail-under-lines 54
       - store_artifacts:
           path: target/llvm-cov/html # Default location
           destination: llvm-cov/html
@@ -126,6 +169,12 @@ jobs:
       - rust-check
       - rust-clippy
 
+  check-for-deployment:
+    docker:
+      - image: cimg/base:2022.08
+    steps:
+      - checkout
+      - skip-if-do-not-deploy
   test:
     docker:
       - image: cimg/rust:<< pipeline.parameters.rust-version >>
@@ -141,6 +190,8 @@ jobs:
       - setup-rust
       - cargo-build
       - run-tests
+      - report-test-results
+      - run-code-coverage
 
   build:
     docker:
@@ -396,8 +447,8 @@ workflows:
       - contract-tests:
           <<: *pr-filters
           requires:
-          - build
-          - contract-test-checks
+            - build
+            - contract-test-checks
       - load-test-checks:
           <<: *pr-filters
 
@@ -420,18 +471,31 @@ workflows:
             - contract-test-checks
       - load-test-checks:
           <<: *main-filters
-      - docker-image-publish-locust:
+      - check-for-deployment:
           <<: *main-filters
           requires:
             - checks
             - test
             - contract-tests
             - load-test-checks
+      - docker-image-publish-locust:
+          <<: *main-filters
+          requires:
+            - check-for-deployment
       - docker-image-publish-stage:
           <<: *main-filters
           requires:
             - docker-image-publish-locust
+      # The following job will require manual approval in the CircleCI web application.
+      # Once provided, and when all the requirements are fullfilled (e.g. tests).
+      - unhold-to-deploy:
+          <<: *main-filters
+          type: approval
+          requires:
+            - docker-image-publish-stage
+      # On approval of the `unhold-to-deploy` job, any successive job that requires it
+      # will run. In this case, it's manually triggering deployment to production.
       - docker-image-publish-prod:
           <<: *main-filters
           requires:
-            - docker-image-publish-stage
+            - unhold-to-deploy

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -15,5 +15,6 @@ _Put an `x` in the boxes that apply_
 - [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
 - [ ] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
 - [ ] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
+- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
 - [ ] Documentation has been updated
 - [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ The goal of this service is to pass tiles from partners along to Firefox for dis
 Supports the TopSites feature within Firefox.
 
 See also:
-
 - [In-repo documentation](docs/)
 - [Monitoring dashboard](https://earthangel-b40313e5.influxcloud.net/d/oak1zw6Gz/contile-infrastructure) (Mozilla internal)
 
@@ -72,11 +71,14 @@ For deployment, you have to add a label to the message of the commit that you wi
 #### Preventing deployment via [do not deploy]
 Occasionally developers might want to prevent a commit from triggering the deployment pipeline. While this should be discouraged, there are some legitimate cases for doing so (e.g. docs only changes).
 In order to prevent the deployment of the code from a PR when merging to `main`, the **title of that PR** must contain the `[do not deploy]` text. When generating the merge commit for a branch within the GitHub UI, ensure that `[do not deploy]` is still present in the description, especially if you change or rename the PR later on.
+
 For example:
+
 ```
 # PR title (NOT the commit message)
 doc: Add documentation for the release process [do not deploy]
 ```
+
 While the `[do not deploy]` can be anywhere in the title, it is recommended to place it at its end in order to better integrate with the current PR title practices and improve readability.
 The deployment pipeline will analyze the message of the merge commit (which will contain the PR title) and make a decision based on it.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ See also:
 
 This system uses [Actix](https://actix.rs/) web, and Google Cloud APIs (currently vendored).
 
+## Development Guidelines
+Please see the [CONTRIBUTING.md][contributing] docs on commit guidelines and pull request best practices.
+
+## Versioning
+The commit hash of the deployed code is considered its version identifier. The commit hash can be retrieved locally via `git rev-parse HEAD`.
+
 ## Setting Up
 
 Contile uses Rust, and requires the latest stable iteration. See
@@ -62,10 +68,46 @@ Load testing can be run locally or as a part of the deployment process. Please s
 
 For deployment, you have to add a label to the message of the commit that you wish to deploy in the form of: `[load test: (abort|warn)]`. In most cases this will be the merge commit created by merging a GitHub pull request. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on this convention, please see the relevant documentation: [Load Test Readme](test-engineering/load/README.md#opt-in-execution-in-staging-and-production).
 
+### Deployment
+#### Preventing deployment via [do not deploy]
+Occasionally developers might want to prevent a commit from triggering the deployment pipeline. While this should be discouraged, there are some legitimate cases for doing so (e.g. docs only changes).
+In order to prevent the deployment of the code from a PR when merging to `main`, the **title of that PR** must contain the `[do not deploy]` text. When generating the merge commit for a branch within the GitHub UI, ensure that `[do not deploy]` is still present in the description, especially if you change or rename the PR later on.
+For example:
+```
+# PR title (NOT the commit message)
+doc: Add documentation for the release process [do not deploy]
+```
+While the `[do not deploy]` can be anywhere in the title, it is recommended to place it at its end in order to better integrate with the current PR title practices and improve readability.
+The deployment pipeline will analyze the message of the merge commit (which will contain the PR title) and make a decision based on it.
+
 #### Releasing to Production
 Developers with write access to the Contile repository can initiate a deployment to production after a Pull-Request on the Contile GitHub repository is merged to the `main` branch.
 
 While any developer with write access can trigger the deployment to production, the _expectation_ is that individual(s) who authored and merged the Pull-Request should do so, as they are the ones most familiar with their changes and who can tell, by looking at the data, if anything looks anomalous.
+
+Releasing to production can be done by:
+
+1. Opening the [CircleCI dashboard][circleci_dashboard];
+2. Looking up the pipeline named after your PR/ticket/branch name, ex. `<PR NUMBER>/<DISCO-1234>` running in the `main-workflow`; this pipeline should either be in a running status (if the required test jobs are still running) or in the "on hold" status, with the `unhold-to-deploy` being held;
+3. Once in the "on hold" status, with all the other jobs successfully completed, clicking on the "thumbs up" action on the `unhold-to-deploy` job row will approve it and trigger the deployment, unblocking the `deploy` job;
+4. Developers **must** monitor the [Contile Operational Status][contile_op_status] dashboard for any anomaly, for example significant changes in HTTP response codes, increase in latency, cpu/memory usage (most things under the infrastructure heading).
+
+[circleci_dashboard]: https://app.circleci.com/pipelines/github/mozilla-services/contile?branch=main&filter=all
+[contile_op_status]: https://earthangel-b40313e5.influxcloud.net/d/Ek54pAmnz/contile-operational-status?orgId=1&refresh=1m
+
+#### What to do if production breaks?
+If your latest release causes problems and needs to be rolled back:
+don't panic and follow the instructions below:
+
+1. Depending on the severity of the problem, decide if this warrants [kicking off an incident][incident_docs];
+2. Identify the problematic commit, as it may not necessarily be the latest one!
+3. Revert the problematic commit, merge that into GitHub,
+   then [deploy the revert commit to production](#releasing-to-production).
+   - If a fix can be identified in a relatively short time,
+     then you may submit a fix, rather than reverting the problematic commit.
+
+[incident_docs]: https://mozilla-hub.atlassian.net/wiki/spaces/MIR/overview
+[contributing]: ./CONTRIBUTING.md
 
 ## Why "Contile"?
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2280](https://mozilla-hub.atlassian.net/browse/DISCO-2280)
GitHub: [#TODO](https://github.com/mozilla-services/contile/issues/TODO)

## Description
In order to empower contributors to skip deployments (example: for documentation changes) and control the flow of changes to staging and production environments, introduce the check-for-deployment and unhold-to-deploy jobs to the Contile CI main-workflow. 

Resource

Example: [Merino CI workflows](https://github.com/mozilla-services/merino-py/blob/main/.circleci/config.yml#L324-L341)

[Adding approval jobs to your CI pipeline](https://circleci.com/blog/adding-approval-jobs-to-your-ci-pipeline/)

Acceptance Criteria

A check-for-deployment job is incorporated into the Contile CI main-workflow

It’s purpose is to detect the “[do not deploy]” text within the merge commit when merging the PR to the 'main' branch and to subsequently stop stage and production Docker Hub image publications.

An unhold-to-deploy job, or approval task, is incorporated into the Contile CI main-workflow

This job will wait for manual confirmation from a contributor before deploying the production Docker Hub images

The [CONTRIBUTING.md](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md), the [PULL_REQUEST_TEMPLATE.md](https://github.com/mozilla-services/contile/blob/main/PULL_REQUEST_TEMPLATE.md%5D) and any other relevant documentation is updated

*Note:* This is a replacement PR for the previous PR, which became un-mergable due to GitHubs service degradation the previous day which prevented several commits from being signed. [Original PR 555](https://github.com/mozilla-services/contile/pull/555)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [ ] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [x] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2280]: https://mozilla-hub.atlassian.net/browse/DISCO-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ