### PR TITLE
[DISCO-1786] Switch to different Docker image in CircleCI publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
     # triggers a webhook that starts the Jenkins deployment workflow. The convention looks as follows:
     #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$
     docker:
-      - image: docker:18.02.0-ce
+      - image: cimg/base:2022.08
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -240,7 +240,7 @@ jobs:
 
   docker-image-publish-prod:
     docker:
-      - image: docker:18.02.0-ce
+      - image: cimg/base:2022.08
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,9 +209,6 @@ jobs:
     #^(?P<environment>stage|prod)(?:-(?P<task>\w+)-(?P<onfailure>warn|abort))?-(?P<commit>[a-z0-9]+)$
     docker:
       - image: cimg/base:2022.08
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
     steps:
       - setup_remote_docker
       - restore_cache:
@@ -241,9 +238,6 @@ jobs:
   docker-image-publish-prod:
     docker:
       - image: cimg/base:2022.08
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
     steps:
       - setup_remote_docker
       - restore_cache:


### PR DESCRIPTION
## References

JIRA: [DISCO-1786](https://mozilla-hub.atlassian.net/browse/DISCO-1786)

## Description

This resolves an issue with `git` being not installed in the Docker image publish job in CircleCI.



[DISCO-1786]: https://mozilla-hub.atlassian.net/browse/DISCO-1786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ