### PR TITLE
fix: Fix the docker-image-publish-stage step for CI [load test: warn]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,7 @@ jobs:
     docker:
       - image: cimg/base:2022.08
     steps:
+      - checkout
       - setup_remote_docker
       - restore_cache:
           key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}


### PR DESCRIPTION
## References

JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)
GitHub: [#TODO](https://github.com/mozilla-services/contile/issues/TODO)

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [ ] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [ ] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title
