### PR TITLE
Update dependabot commit messages with tags [do not deploy]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+    commit-message:
+      # Contract tests are run in PR workflow, skip deploy
+      prefix: "[do not deploy]"
     labels:
       - "dependencies"
       - "python"
@@ -14,6 +17,21 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+    commit-message:
+      # Contract tests are run in PR workflow, skip deploy
+      prefix: "[do not deploy]"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "pip"
+    directory: "test-engineering/load/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    commit-message:
+      # Run the load test when updating load test dependency
+      prefix: "[load test: warn]"
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
## Description
We want to drop deploying contract test updates because those are run during the PR workflow. We also want to run load tests for updates that involve load tests dependency updates so that we can catch problems with load tests if the dependency breaks something.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [ ] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [ ] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title
