### PR TITLE
[DISCO-2415] fix: Fix the code coverage threshold

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,10 +97,10 @@ commands:
           name: Install cargo-llvm-cov
           command: cargo install cargo-llvm-cov
       - run:
-          name: Run and report tests and coverage (Minimum 54%)
+          name: Run and report tests and coverage (Minimum 67%)
           command: |
-            cargo llvm-cov --no-report test -- -Z unstable-options --format json --report-time | cargo2junit > results.xml && \
-            cargo llvm-cov report --fail-under-lines 54 --html
+            cargo llvm-cov --no-report test -- -Z unstable-options --format json --report-time | cargo2junit > results.xml
+            cargo llvm-cov report --fail-under-lines 67 --html
       - store_test_results:
           path: results.xml
       - store_artifacts:


### PR DESCRIPTION
## References

JIRA: [DISCO-2145](https://mozilla-hub.atlassian.net/browse/DISCO-2415)
GitHub: N/A

## Description
Fix the wrong code coverage threshold in CI.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [ ] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2145]: https://mozilla-hub.atlassian.net/browse/DISCO-2145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ