### PR TITLE
fix: Add 304 an expected status [load test: warn]

### DIFF
--- a/test-engineering/load/locustfiles/locustfile.py
+++ b/test-engineering/load/locustfiles/locustfile.py
@@ -45,9 +45,9 @@ class ContileFirefoxUser(FastHttpUser):
         with self.client.get(
             url=TILES_API, headers=headers, catch_response=True, name=name
         ) as response:
-            if response.status_code not in (200, 204):
+            if response.status_code not in (200, 204, 304):
                 response.failure(
-                    f"{response.status_code=}, expected 200, {response.text=}"
+                    f"{response.status_code=}, expected 200,204,304 {response.text=}"
                 )
             if response.status_code == 0:
                 # Do not classify as failure


### PR DESCRIPTION
## Description
304 is an expected status code and therefore load tests should not fail then 304s are returned


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [ ] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [X] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [X] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title
