### PR TITLE
[DISCO-2419] fix: Only include sov for desktop requests

### DIFF
--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -267,9 +267,7 @@ pub async fn get_tiles(
         settings.adm_max_tiles
     });
     for tile in iter {
-        if let Some(tile) =
-            filter.filter_and_process(tile, location, device_info, tags, metrics)?
-        {
+        if let Some(tile) = filter.filter_and_process(tile, location, device_info, tags, metrics)? {
             filtered.push(tile);
         }
         if filtered.len() == max_tiles {

--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -129,7 +129,7 @@ pub fn filtered_dma(exclude: &Option<Vec<u16>>, dma: &u16) -> String {
 pub async fn get_tiles(
     state: &ServerState,
     location: &Location,
-    device_info: DeviceInfo,
+    device_info: &DeviceInfo,
     tags: &mut Tags,
     metrics: &Metrics,
     headers: Option<&HeaderMap>,

--- a/src/adm/tiles.rs
+++ b/src/adm/tiles.rs
@@ -136,7 +136,7 @@ pub async fn get_tiles(
 ) -> HandlerResult<TileResponse> {
     let settings = &state.settings;
     let image_store = &state.img_store;
-    let pse = AdmPse::appropriate_from_settings(&device_info, settings);
+    let pse = AdmPse::appropriate_from_settings(device_info, settings);
     let country_code = location
         .country
         .as_deref()
@@ -268,7 +268,7 @@ pub async fn get_tiles(
     });
     for tile in iter {
         if let Some(tile) =
-            filter.filter_and_process(tile, location, &device_info, tags, metrics)?
+            filter.filter_and_process(tile, location, device_info, tags, metrics)?
         {
             filtered.push(tile);
         }

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -122,7 +122,7 @@ pub async fn get_tiles(
     let result = adm::get_tiles(
         &state,
         &location,
-        device_info,
+        &device_info,
         &mut tags,
         &metrics,
         // be aggressive about not passing headers unless we absolutely need to
@@ -136,7 +136,12 @@ pub async fn get_tiles(
 
     match result {
         Ok(response) => {
-            let sov_response = state.sov_manager.read().await.encoded_sov.clone();
+            // SOV is for Desktop only for now.
+            let sov_response = if matches!(device_info.form_factor, FormFactor::Desktop) {
+                state.sov_manager.read().await.encoded_sov.clone()
+            } else {
+                None
+            };
             let tiles = cache::Tiles::new(
                 TilesHandlerResponse {
                     tile_response: response,

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -604,6 +604,9 @@ async fn basic_mobile() {
     assert!(!tiles
         .iter()
         .any(|tile| tile["name"].as_str().unwrap() == "Los Pollos Hermanos"));
+
+    // mobile should not carry the `sov` payload.
+    assert!(result["sov"].is_null());
 }
 
 #[actix_web::test]

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -337,7 +337,6 @@ scenarios:
         response:
           status_code: 200
           content:
-            sov: *sov
             tiles:
               - id: 32348
                 name: 'Example COM'


### PR DESCRIPTION
## References

JIRA: [DISCO-2419](https://mozilla-hub.atlassian.net/browse/DISCO-2419)
GitHub: N/A

## Description
SOV is scoped for Desktop only for this MVP, no need to send SOV settings to other platforms for now.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2419]: https://mozilla-hub.atlassian.net/browse/DISCO-2419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ