### PR TITLE
fix: 304 response filtering in load tests [load test: abort]

### DIFF
--- a/test-engineering/load/locustfiles/locustfile.py
+++ b/test-engineering/load/locustfiles/locustfile.py
@@ -45,17 +45,21 @@ class ContileFirefoxUser(FastHttpUser):
         with self.client.get(
             url=TILES_API, headers=headers, catch_response=True, name=name
         ) as response:
-            if response.status_code not in (200, 204, 304):
-                response.failure(
-                    f"{response.status_code=}, expected 200,204,304 {response.text=}"
-                )
-            if response.status_code == 0:
+            if response.status_code in (0, 304):
                 # Do not classify as failure
-                # The HttpSession catches any requests.RequestException thrown by
-                # Session (caused by connection errors, timeouts or similar),
-                # instead returning a dummy Response object with status_code set to 0
-                # and content set to None.
+                #
+                # 0: The HttpSession catches any requests.RequestException thrown by
+                #    Session (caused by connection errors, timeouts or similar), instead
+                #    returning a dummy Response object with status_code set to 0 and
+                #    content set to None.
+                #
+                # 304: Is an expected and acceptable status code for Contile when it's
+                #      normalizing User Agent info and the search cache.
                 response.success()
+            elif response.status_code not in (200, 204):
+                response.failure(
+                    f"{response.status_code=}, expected 200,204 {response.text=}"
+                )
 
 
 class ContileNonFirefoxUser(FastHttpUser):


### PR DESCRIPTION
## References

JIRA: N/A
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

The 304 status code is an expected and acceptable response from Contile; However, the load tests are categorizing responses of this type as 'BadStatusCode'. This PR aims to fix this miss-understanding by setting `response.success()` explicitly.

Related PR: https://github.com/mozilla-services/contile/pull/574

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] Documentation has been updated
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title
