### PR TITLE
[DISCO-2249] Delete Contile CI approval task for the production deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
           paths:
             - /home/circleci/cache
 
-  docker-image-publish-stage:
+  docker-image-publish:
     # The commit tag signals deployment and load test instructions to Jenkins by
     # modifying the Docker image tag name. Pushing a new Docker image to the Docker Hub registry
     # triggers a webhook that starts the Jenkins deployment workflow. The convention looks as follows:
@@ -219,7 +219,7 @@ jobs:
           command: docker load -i /home/circleci/cache/docker.tar
       - dockerhub-login
       - run:
-          name: Deploy to Dockerhub
+          name: Deploy Stage to Dockerhub
           command: |
             if git log -1 "$CIRCLE_SHA1" | grep -q '\[load test: warn\]'; then
               echo "Load test requested. Slack warning will be output if test fails and deployment workflow for prod will proceed."
@@ -230,25 +230,12 @@ jobs:
             else
               STAGE_DOCKER_TAG="stage-${CIRCLE_SHA1}"
             fi
-
             echo ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
             docker tag app:build ${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}
             docker images
             docker push "${DOCKERHUB_REPO}:${STAGE_DOCKER_TAG}"
-
-  docker-image-publish-prod:
-    docker:
-      - image: cimg/base:2022.08
-    steps:
-      - setup_remote_docker
-      - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
-          name: Restore Docker image cache
-          command: docker load -i /home/circleci/cache/docker.tar
-      - dockerhub-login
-      - run:
-          name: Deploy to Dockerhub
+          name: Deploy Production to Dockerhub
           command: |
             PROD_DOCKER_TAG="prod-${CIRCLE_SHA1}"
             echo "${DOCKERHUB_REPO}:${PROD_DOCKER_TAG}"
@@ -451,20 +438,7 @@ workflows:
           <<: *main-filters
           requires:
             - check-for-deployment
-      - docker-image-publish-stage:
+      - docker-image-publish:
           <<: *main-filters
           requires:
             - docker-image-publish-locust
-      # The following job will require manual approval in the CircleCI web application.
-      # Once provided, and when all the requirements are fullfilled (e.g. tests).
-      - unhold-to-deploy:
-          <<: *main-filters
-          type: approval
-          requires:
-            - docker-image-publish-stage
-      # On approval of the `unhold-to-deploy` job, any successive job that requires it
-      # will run. In this case, it's manually triggering deployment to production.
-      - docker-image-publish-prod:
-          <<: *main-filters
-          requires:
-            - unhold-to-deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,24 +69,6 @@ commands:
             "$CIRCLE_PROJECT_USERNAME" \
             "$CIRCLE_PROJECT_REPONAME" \
             "$CIRCLE_BUILD_URL" > version.json
-  skip-if-do-not-deploy:
-    steps:
-      - run:
-          name: Check if deployment is disallowed
-          # This relies on the [do not deploy] text to be available in the
-          # merge commit when merging the PR to 'main'.
-          command: |
-            if git log -1 "$CIRCLE_SHA1" | grep -q '\[do not deploy\]'; then
-                echo "Skipping remaining steps in this job: deployment was disabled for this commit."
-                circleci-agent step halt
-
-                # No need to deploy, just cancel the rest of jobs of the workflow.
-                # See API detail: https://circleci.com/docs/api/v2/index.html#operation/cancelWorkflow
-
-                curl -X POST https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel \
-                -H 'Accept: application/json' \
-                -H "Circle-Token: ${SKIP_DEPLOY_API_TOKEN}"
-            fi
 
   run-tests:
     steps:
@@ -143,13 +125,6 @@ jobs:
       - setup-rust-check
       - rust-check
       - rust-clippy
-
-  check-for-deployment:
-    docker:
-      - image: cimg/base:2022.08
-    steps:
-      - checkout
-      - skip-if-do-not-deploy
 
   test:
     docker:
@@ -427,17 +402,13 @@ workflows:
             - contract-test-checks
       - load-test-checks:
           <<: *main-filters
-      - check-for-deployment:
+      - docker-image-publish-locust:
           <<: *main-filters
           requires:
             - checks
             - test
             - contract-tests
             - load-test-checks
-      - docker-image-publish-locust:
-          <<: *main-filters
-          requires:
-            - check-for-deployment
       - docker-image-publish:
           <<: *main-filters
           requires:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
-    commit-message:
-      # Contract tests are run in PR workflow, skip deploy
-      prefix: "[do not deploy]"
     labels:
       - "dependencies"
       - "python"
@@ -17,9 +14,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
-    commit-message:
-      # Contract tests are run in PR workflow, skip deploy
-      prefix: "[do not deploy]"
     labels:
       - "dependencies"
       - "python"

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,6 @@ _Put an `x` in the boxes that apply_
 - [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
 - [ ] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
 - [ ] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
-- [ ] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
+- [ ] The `[load test: (abort|warn)]` keywords are applied (if applicable)
 - [ ] Documentation has been updated
 - [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title

--- a/README.md
+++ b/README.md
@@ -83,19 +83,19 @@ While the `[do not deploy]` can be anywhere in the title, it is recommended to p
 The deployment pipeline will analyze the message of the merge commit (which will contain the PR title) and make a decision based on it.
 
 #### Releasing to Production
-Developers with write access to the Contile repository can initiate a deployment to production after a Pull-Request on the Contile GitHub repository is merged to the `main` branch.
 
-While any developer with write access can trigger the deployment to production, the _expectation_ is that individual(s) who authored and merged the Pull-Request should do so, as they are the ones most familiar with their changes and who can tell, by looking at the data, if anything looks anomalous.
+Developers with write access to the Contile repository will initiate a deployment to production when
+a pull request on the Contile GitHub repository is merged to the `main` branch. It is recommended to
+merge pull requests during hours when the majority of Contile contributors are online.
 
-Releasing to production can be done by:
+While any developer with write access can trigger the deployment to production, the _expectation_ is
+that the individual(s) who authored and merged the pull request should do so, as they are the ones
+most familiar with their changes and who can tell, by looking at the data, if anything looks
+anomalous. Developers **must** monitor the [Contile Infrastructure][contile_infrastructure]
+dashboard for any anomaly, for example significant changes in HTTP response codes, increase in
+latency, cpu/memory usage (most things under the 'Metrics' heading).
 
-1. Opening the [CircleCI dashboard][circleci_dashboard];
-2. Looking up the pipeline named after your PR/ticket/branch name, ex. `<PR NUMBER>/<DISCO-1234>` running in the `main-workflow`; this pipeline should either be in a running status (if the required test jobs are still running) or in the "on hold" status, with the `unhold-to-deploy` being held;
-3. Once in the "on hold" status, with all the other jobs successfully completed, clicking on the "thumbs up" action on the `unhold-to-deploy` job row will approve it and trigger the deployment, unblocking the `deploy` job;
-4. Developers **must** monitor the [Contile Operational Status][contile_op_status] dashboard for any anomaly, for example significant changes in HTTP response codes, increase in latency, cpu/memory usage (most things under the infrastructure heading).
-
-[circleci_dashboard]: https://app.circleci.com/pipelines/github/mozilla-services/contile?branch=main&filter=all
-[contile_op_status]: https://earthangel-b40313e5.influxcloud.net/d/oak1zw6Gz/contile-infrastructure?orgId=1&refresh=1m
+[contile_infrastructure]: https://earthangel-b40313e5.influxcloud.net/d/oak1zw6Gz/contile-infrastructure?orgId=1&refresh=1m
 
 #### What to do if production breaks?
 If your latest release causes problems and needs to be rolled back:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ See also:
 This system uses [Actix](https://actix.rs/) web, and Google Cloud APIs (currently vendored).
 
 ## Development Guidelines
-Please see the [CONTRIBUTING.md][contributing] docs on commit guidelines and pull request best practices.
+Please see the [CONTRIBUTING.md](./CONTRIBUTING.md) docs on commit guidelines and pull request best
+practices.
 
 ## Versioning
 The commit hash of the deployed code is considered its version identifier. The commit hash can be retrieved locally via `git rev-parse HEAD`.
@@ -69,18 +70,6 @@ Load testing can be run locally or as a part of the deployment process. Please s
 For deployment, you have to add a label to the message of the commit that you wish to deploy in the form of: `[load test: (abort|warn)]`. In most cases this will be the merge commit created by merging a GitHub pull request. Abort will prevent deployment should the load testing fail while warn will simply warn via Slack and continue deployment. For detailed specifics on this convention, please see the relevant documentation: [Load Test Readme](test-engineering/load/README.md#opt-in-execution-in-staging-and-production).
 
 ### Deployment
-#### Preventing deployment via [do not deploy]
-Occasionally developers might want to prevent a commit from triggering the deployment pipeline. While this should be discouraged, there are some legitimate cases for doing so (e.g. docs only changes).
-In order to prevent the deployment of the code from a PR when merging to `main`, the **title of that PR** must contain the `[do not deploy]` text. When generating the merge commit for a branch within the GitHub UI, ensure that `[do not deploy]` is still present in the description, especially if you change or rename the PR later on.
-
-For example:
-```
-# PR title (NOT the commit message)
-doc: Add documentation for the release process [do not deploy]
-```
-
-While the `[do not deploy]` can be anywhere in the title, it is recommended to place it at its end in order to better integrate with the current PR title practices and improve readability.
-The deployment pipeline will analyze the message of the merge commit (which will contain the PR title) and make a decision based on it.
 
 #### Releasing to Production
 
@@ -109,7 +98,6 @@ don't panic and follow the instructions below:
      then you may submit a fix, rather than reverting the problematic commit.
 
 [incident_docs]: https://mozilla-hub.atlassian.net/wiki/spaces/MIR/overview
-[contributing]: ./CONTRIBUTING.md
 
 ## Why "Contile"?
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2249](https://mozilla-hub.atlassian.net/browse/DISCO-2249)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->

- Update the Contile CircleCI Workflow
  - Remove the unhold-to-deploy job
  - Merge the docker-image-publish-stage and docker-image-publish-prod jobs
  - Remove the check-for-deployment job
- Update the dependabot configuration
- Update the README.md and PULL_REQUEST_TEMPLATE.md Documentation

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [x] `[do not deploy]` and `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2249]: https://mozilla-hub.atlassian.net/browse/DISCO-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ