### PR TITLE
[DISCO-2452] Add Instruction for Image Only Deployment (Setup) In Load Test Documentation [load test: abort]

### DIFF
--- a/test-engineering/load/README.md
+++ b/test-engineering/load/README.md
@@ -164,6 +164,9 @@ shell commands to **create** a GKE cluster, **setup** an existing GKE cluster or
   ```bash
   kubectl scale deployment/locust-worker --replicas=10
   ```
+* To apply new changes to an existing GCP Cluster, execute the `setup_k8s.sh` file and select the
+  **setup** option. This option will consider the local commit history, creating new containers and
+  deploying them (see [Container Registry][16])
 
 ### Run Test Session
 
@@ -247,3 +250,4 @@ Execute the `setup_k8s.sh` file and select the **delete** option
 [13]: https://docs.google.com/document/d/10Hx4cGvGBvq0z0uOK_CG3ZcyaQnT_EtgR6MYXmIvG6Q/
 [14]: https://docs.locust.io/en/stable/configuration.html#environment-variables
 [15]: https://docs.locust.io/en/stable/running-in-debugger.html
+[16]: https://console.cloud.google.com/gcr/images/spheric-keel-331521/global/locust-merino?project=spheric-keel-331521


### PR DESCRIPTION
## References

JIRA: [DISCO-2452](https://mozilla-hub.atlassian.net/browse/DISCO-2452)
GitHub: #336 

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
During the execution of Merino-py load tests on June 19th 2023, the need to provide an instruction for the **setup** option in the load test script was identified. This applies to Contile as well.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [X] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [X] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [X] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [X] Documentation has been updated
- [X] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2452]: https://mozilla-hub.atlassian.net/browse/DISCO-2452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ