### PR TITLE
[DISCO-2455] chore: fix Cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,4 +10,5 @@ ignore = [
     "RUSTSEC-2021-0124", # Bound by tokio restrictions
 
     "RUSTSEC-2021-0141", # dotenv is no longer being maintained, will need to remove
+    "RUSTSEC-2021-0145", # Only affects Windows. Fix tracked at https://github.com/slog-rs/term/pull/45 in Atty
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,9 +1650,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1682,9 +1682,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## References

JIRA: [DISCO-2455](https://mozilla-hub.atlassian.net/browse/DISCO-2455)
GitHub: N/A

## Description

- Whitelisted [RUSTSEC-2021-0145] for atty as it only affects Windows.
- Updated openssl to the latest


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [ ] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2455]: https://mozilla-hub.atlassian.net/browse/DISCO-2455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ