### PR TITLE
chore: add more dependency filters to smoke-tests dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,19 @@ updates:
     schedule:
       interval: "monthly"
     ignore:
+      - dependency-name: "click"
+      - dependency-name: "cloudevents"
+      - dependency-name: "deprecation"
       - dependency-name: "flask"
+      - dependency-name: "functions-framework"
+      - dependency-name: "gunicorn"
+      - dependency-name: "itsdangerous"
+      - dependency-name: "jinja2"
+      - dependency-name: "markupsafe"
+      - dependency-name: "pathtools"
       - dependency-name: "requests"
+      - dependency-name: "watchdog"
+      - dependency-name: "werkzeug"
     labels:
       - "dependencies"
       - "python"
@@ -16,8 +27,20 @@ updates:
     schedule:
       interval: "monthly"
     ignore:
+      - dependency-name: "click"
+      - dependency-name: "cloudevents"
+      - dependency-name: "deprecation"
       - dependency-name: "flask"
+      - dependency-name: "functions-framework"
+      - dependency-name: "google-auth"
+      - dependency-name: "gunicorn"
+      - dependency-name: "itsdangerous"
+      - dependency-name: "jinja2"
+      - dependency-name: "markupsafe"
+      - dependency-name: "pathtools"
       - dependency-name: "requests"
+      - dependency-name: "watchdog"
+      - dependency-name: "werkzeug"
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
## References

JIRA: N/A
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Add more dependencies to ignore for smoke tests. Is there a better way?

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [x] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title
