### PR TITLE
[DISCO-2472] Load Test Script Modifies Kubernetes Config On First Run Only [load test: abort]

### DIFF
--- a/test-engineering/load/README.md
+++ b/test-engineering/load/README.md
@@ -165,8 +165,10 @@ shell commands to **create** a GKE cluster, **setup** an existing GKE cluster or
   kubectl scale deployment/locust-worker --replicas=10
   ```
 * To apply new changes to an existing GCP Cluster, execute the `setup_k8s.sh` file and select the
-  **setup** option. This option will consider the local commit history, creating new containers and
-  deploying them (see [Container Registry][16])
+  **setup** option.
+    * This option will consider the local commit history, creating new containers and
+      deploying them (see [Container Registry][16])
+    * **Reset the files in the `kubernetes-config` directory between executions of the script**
 
 ### Run Test Session
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2472](https://mozilla-hub.atlassian.net/browse/DISCO-2472)
GitHub: N/A

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Add workaround instruction to the load test Distributed GCP Execution procedure

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [x] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title
