### PR TITLE
[DISCO-2391] Upload Contract Test Results to CircleCI Test Insights

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,29 +89,6 @@ commands:
           path: target/llvm-cov/html # Default location
           destination: llvm-cov/html
 
-  setup-sccache:
-    steps:
-      - run:
-          name: Install sccache
-          command: |
-            cargo install sccache
-            # This configures Rust to use sccache.
-            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
-            # This is the maximum space sccache cache will use on disk.
-            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
-            sccache --version
-  restore-sccache-cache:
-    steps:
-      - restore_cache:
-          name: Restore sccache cache
-          key: sccache-cache-stable-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
-  save-sccache-cache:
-    steps:
-      - save_cache:
-          name: Save sccache cache
-          key: sccache-cache-stable-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
-          paths:
-            - "~/.cache/sccache"
 jobs:
   checks:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,11 +153,9 @@ jobs:
           # XXX: begin_test_transaction doesn't play nice over threaded tests
           RUST_TEST_THREADS: 1
     steps:
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - dockerhub-login
-      #- save-sccache-cache
-      - checkout
       - write-version
       - run:
           name: Build Docker image
@@ -165,17 +163,16 @@ jobs:
             docker build \
               -t app:build \
               --build-arg VERSION="$(echo ${CIRCLE_SHA1} | cut -c -7)" .
-      # save the built docker container into CircleCI's cache. This is
-      # required since Workflows do not have the same remote docker instance.
       - run:
-          name: docker save app:build
+          name: Save image into workspace
           command: |
-            mkdir -p /home/circleci/cache
-            docker save -o /home/circleci/cache/docker.tar "app:build"
-      - save_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}-{{ epoch }}
+            mkdir -p /tmp/workspace
+            docker save -o /tmp/workspace/contile.tar app:build
+            gzip /tmp/workspace/contile.tar
+      - persist_to_workspace:
+          root: /tmp/workspace
           paths:
-            - /home/circleci/cache
+            - contile.tar.gz
 
   docker-image-publish:
     # The commit tag signals deployment and load test instructions to Jenkins by
@@ -186,12 +183,12 @@ jobs:
       - image: cimg/base:2022.08
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/workspace
       - setup_remote_docker
-      - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
       - run:
-          name: Restore Docker image cache
-          command: docker load -i /home/circleci/cache/docker.tar
+          name: Load Docker image from workspace
+          command: docker load -i /tmp/workspace/contile.tar.gz
       - dockerhub-login
       - run:
           name: Deploy Stage to Dockerhub
@@ -247,20 +244,15 @@ jobs:
 
   contract-tests:
     machine:
-      docker_layer_caching: true
       image: ubuntu-2004:2023.04.2
     working_directory: ~/contile
     steps:
       - checkout
-      - restore_cache:
-          key: v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
-          name: Restore Docker image cache
-          command: docker load -i /home/circleci/cache/docker.tar
-      - run:
-          name: Log in to the default Docker registry
-          command: |
-            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          name: Load Docker image from workspace
+          command: docker load -i /tmp/workspace/contile.tar.gz
       - run:
           name: Build client and partner images
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,8 @@ jobs:
           command: docker load -i /tmp/workspace/contile.tar.gz
       - run:
           name: Build client and partner images
+          environment:
+            TEST_RESULTS_DIR: test-results
           command: |
             docker-compose --version
             docker-compose \
@@ -239,12 +241,18 @@ jobs:
              build client partner
       - run:
           name: Run contract tests
+          environment:
+            TEST_RESULTS_DIR: test-results
+            TEST_RESULTS_XML: contract_results.xml
           command: |
             docker-compose \
              -f test-engineering/contract-tests/docker-compose.yml \
              up --abort-on-container-exit --force-recreate
       - run:
           name: Run "tiles cache" contract tests
+          environment:
+            TEST_RESULTS_DIR: test-results
+            TEST_RESULTS_XML: contract_results.tiles_cache.xml
           command: |
             docker-compose \
              -f test-engineering/contract-tests/docker-compose.yml \
@@ -252,6 +260,9 @@ jobs:
              up --abort-on-container-exit --force-recreate
       - run:
           name: Run "204" contract tests
+          environment:
+            TEST_RESULTS_DIR: test-results
+            TEST_RESULTS_XML: contract_results.204.xml
           command: |
             docker-compose \
              -f test-engineering/contract-tests/docker-compose.yml \
@@ -273,6 +284,8 @@ jobs:
              echo "Contile service exit_code: ${contile_exit_code}"
              exit 0
             fi
+      - store_test_results:
+          path: test-engineering/contract-tests/test-results
 
   load-test-checks:
     docker:

--- a/test-engineering/.gitignore
+++ b/test-engineering/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+test-results/
 
 # Translations
 *.mo

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -99,6 +99,7 @@ services:
       SCENARIOS_FILE: /tmp/client/scenarios.yml
     volumes:
       - ./volumes/client:/tmp/client
+      - ./${TEST_RESULTS_DIR:-test-results}:/tmp/test-results
     ## This pulls in knot-dnsutils because it's the only dnsutil
     ## package that is available for the host docker image. This line can
     ## be useful if the tests fail due to connection errors. See also
@@ -106,4 +107,4 @@ services:
     #entrypoint: >
     #  /bin/sh -c "apt update -y && apt install knot-dnsutils -y && hostname -I && kdig contile +short && kdig localhost +short"
     command: >
-      "-vv"
+      --junit-xml=/tmp/test-results/${TEST_RESULTS_XML:-contract_results.xml} -vv


### PR DESCRIPTION
## References

JIRA: [DISCO-2391](https://mozilla-hub.atlassian.net/browse/DISCO-2391)
GitHub: #606 

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- update the CircleCI config
    - Use a workspace instead of the cache for persisting the contile Docker image
        - According to this [article](https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/) the workspace seems the more appropriate solution
        - Making this switch resolved instability in contract tests
    - remove the setup-sccache, restore-sccache-cache and save-sccache-cache commands
        - they seem to be unused? 
- report contract test results to CircleCI to take advantage of insights 
    - Note the 'init_error' contract tests can't be reported, since they fail deliberately 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [x] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2391]: https://mozilla-hub.atlassian.net/browse/DISCO-2391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ