### PR TITLE
[DISCO-2472] Contile: Load Test Script Modifies Kubernetes Config On First Run Only [load test: warn]

### DIFF
--- a/test-engineering/load/README.md
+++ b/test-engineering/load/README.md
@@ -253,4 +253,4 @@ Execute the `setup_k8s.sh` file and select the **delete** option
 [13]: https://docs.google.com/document/d/10Hx4cGvGBvq0z0uOK_CG3ZcyaQnT_EtgR6MYXmIvG6Q/
 [14]: https://docs.locust.io/en/stable/configuration.html#environment-variables
 [15]: https://docs.locust.io/en/stable/running-in-debugger.html
-[16]: https://console.cloud.google.com/gcr/images/spheric-keel-331521/global/locust-merino?project=spheric-keel-331521
+[16]: https://console.cloud.google.com/gcr/images/spheric-keel-331521/global/locust-contile?project=spheric-keel-331521

--- a/test-engineering/load/README.md
+++ b/test-engineering/load/README.md
@@ -168,7 +168,6 @@ shell commands to **create** a GKE cluster, **setup** an existing GKE cluster or
   **setup** option.
     * This option will consider the local commit history, creating new containers and
       deploying them (see [Container Registry][16])
-    * **Reset the files in the `kubernetes-config` directory between executions of the script**
 
 ### Run Test Session
 

--- a/test-engineering/load/README.md
+++ b/test-engineering/load/README.md
@@ -216,7 +216,7 @@ the load test will stop automatically.
 
 * Results should be recorded in the [Contile Load Test Spreadsheet][11]
 * Optionally, the Locust reports can be saved and linked in the spreadsheet:
-  * Download the results via command:
+  * Download the results via the Locust UI or via command:
       ```bash
       kubectl cp <master-pod-name>:/home/locust/contile_stats.csv contile_stats.csv
       kubectl cp <master-pod-name>:/home/locust/contile_exceptions.csv contile_exceptions.csv
@@ -226,7 +226,8 @@ the load test will stop automatically.
       ```bash 
       kubectl get pods -o wide
       ```
-  * Upload the files to [gist][12] and record the links
+  * Upload the files to the [ConServ][12] drive and record the links in the 
+    spreadsheet
 
 ### Clean-up Environment
 
@@ -248,7 +249,7 @@ Execute the `setup_k8s.sh` file and select the **delete** option
 [9]: https://console.cloud.google.com/home/dashboard?q=search&referrer=search&project=spheric-keel-331521&cloudshell=false
 [10]: https://earthangel-b40313e5.influxcloud.net/d/oak1zw6Gz/contile-infrastructure?orgId=1&refresh=1m&var-environment=stage
 [11]: https://docs.google.com/spreadsheets/d/1lGHu--eXEy6ShErmU1-SQ26yLY4xOjGubnRXt0DdGB0/
-[12]: https://gist.github.com/new
+[12]: https://drive.google.com/drive/folders/1A7haAcel4O5-xFPW-pdKuVriGrNDqA-F
 [13]: https://docs.google.com/document/d/10Hx4cGvGBvq0z0uOK_CG3ZcyaQnT_EtgR6MYXmIvG6Q/
 [14]: https://docs.locust.io/en/stable/configuration.html#environment-variables
 [15]: https://docs.locust.io/en/stable/running-in-debugger.html

--- a/test-engineering/load/kubernetes-config/locust-master-controller.yml
+++ b/test-engineering/load/kubernetes-config/locust-master-controller.yml
@@ -21,21 +21,21 @@ spec:
             - name: LOCUST_MODE_MASTER
               value: "true"
             - name: TARGET_HOST
-              value: [TARGET_HOST]
+              value:
             - name: LOCUST_CSV
-              value: [LOCUST_CSV]
+              value:
             - name: LOCUST_HOST
-              value: [LOCUST_HOST]
+              value:
             - name: LOCUST_USERS
-              value: "[LOCUST_USERS]"
+              value:
             - name: LOCUST_SPAWN_RATE
-              value: "[LOCUST_SPAWN_RATE]"
+              value:
             - name: LOCUST_RUN_TIME
-              value: "[LOCUST_RUN_TIME]"
+              value:
             - name: LOCUST_LOGLEVEL
-              value: [LOCUST_LOGLEVEL]
+              value:
             - name: CONTILE_LOCATION_TEST_HEADER
-              value: [CONTILE_LOCATION_TEST_HEADER]
+              value:
           ports:
             - name: loc-master-web
               containerPort: 8089

--- a/test-engineering/load/kubernetes-config/locust-worker-controller.yml
+++ b/test-engineering/load/kubernetes-config/locust-worker-controller.yml
@@ -23,8 +23,8 @@ spec:
             - name: LOCUST_MASTER_NODE_HOST
               value: locust-master
             - name: TARGET_HOST
-              value: [TARGET_HOST]
+              value:
             - name: LOCUST_LOGLEVEL
-              value: [LOCUST_LOGLEVEL]
+              value:
             - name: CONTILE_LOCATION_TEST_HEADER
-              value: [CONTILE_LOCATION_TEST_HEADER]
+              value:


### PR DESCRIPTION
## References

JIRA: [DISCO-2472](https://mozilla-hub.atlassian.net/browse/DISCO-2472)
GitHub: #350 

## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->
- Improve load test setup script by using patterns fixed on constants instead of placeholders
- Update load test README

**Related PR:** https://github.com/mozilla-services/merino-py/pull/363

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [ ] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [x] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2472]: https://mozilla-hub.atlassian.net/browse/DISCO-2472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ