### PR TITLE
[DISCO-2516] fix: Return HTTP 204 for excluded regions

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -169,7 +169,7 @@ impl Default for Settings {
             exclude_dma: Some("[798, 583, 740]".to_owned()),
             connect_timeout: 2,
             request_timeout: 5,
-            excluded_countries_200: true,
+            excluded_countries_200: false,
             cache_control_header: true,
             // ADM specific settings
             adm_endpoint_url: "".to_owned(),

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -738,6 +738,7 @@ async fn empty_tiles_returns_no_content() {
     let adm_settings = filters;
     let mut settings = Settings {
         adm_endpoint_url: adm.endpoint_url,
+        excluded_countries_200: true,
         adm_settings,
         ..get_test_settings()
     };
@@ -808,6 +809,7 @@ async fn empty_tiles_excluded_country() {
     let mut settings = Settings {
         adm_endpoint_url: adm.endpoint_url,
         adm_settings,
+        excluded_countries_200: true,
         ..get_test_settings()
     };
     let app = init_app!(settings).await;
@@ -841,7 +843,6 @@ async fn empty_tiles_excluded_country_204() {
     // considered "excluded"
     let mut settings = Settings {
         adm_endpoint_url: adm.endpoint_url,
-        excluded_countries_200: false,
         ..get_test_settings()
     };
     let app = init_app!(settings).await;
@@ -1180,6 +1181,7 @@ async fn no_sov() {
 
     let mut settings = Settings {
         adm_endpoint_url: adm.endpoint_url,
+        excluded_countries_200: true,
         sov_source: "gs://bad.bucket".to_owned(),
         ..get_test_settings()
     };

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -353,8 +353,8 @@ scenarios:
                 impression_url: 'https://example.org/gb_phone_ios?id=0002'
                 url: 'https://www.example.org/gb_phone_ios'
 
-  - name: success_200_OK_excluded_region
-    description: Test that Contile returns a 200 OK with an empty tiles array for excluded regions
+  - name: success_204_NO_CONTENT_excluded_region
+    description: Test that Contile returns a 204 (No Content) for excluded regions
     steps:
       - request:
           service: contile
@@ -372,9 +372,8 @@ scenarios:
             - name: X-Forwarded-For
               value: '89.160.20.115'
         response:
-          status_code: 200
-          content:
-           tiles: []
+          status_code: 204
+          content: ''
 
   - name: advertiser_url_path_filter_prefix
     description: >


### PR DESCRIPTION
## References

JIRA: [DISCO-2516](https://mozilla-hub.atlassian.net/browse/DISCO-2516)
GitHub: N/A

## Description

Firefox now can handle HTTP 204 properly, Contile can return HTTP 204 for excluded regions. This flips the pref added in #290.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [ ] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2516]: https://mozilla-hub.atlassian.net/browse/DISCO-2516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ