### PR TITLE
[DISCO-2506] Service Overview Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,53 +12,7 @@ See also:
 - [Documentation](https://mozilla-services.github.io/contile/)
 - [Monitoring dashboard](https://earthangel-b40313e5.influxcloud.net/d/oak1zw6Gz/contile-infrastructure) (Mozilla internal)
 
-## Requirements
 
-This system uses [Actix](https://actix.rs/) web, and Google Cloud APIs (currently vendored).
-
-## Development Guidelines
-Please see the [CONTRIBUTING.md](./CONTRIBUTING.md) docs on commit guidelines and pull request best
-practices.
-
-## Versioning
-The commit hash of the deployed code is considered its version identifier. The commit hash can be retrieved locally via `git rev-parse HEAD`.
-
-## Development Setup
-1. Install Rust. See [rustup.rs](https://rustup.rs/) for how to install on your platform.
-2. Compile Contile using `cargo build`.
-3. Start connection a local ADM instance (run from root of Contile repo):
-    ```shell
-        docker run \
-        --env PORT=5000 \
-        --env RESPONSES_DIR=/tmp/partner/ \
-        --env ACCEPTED_MOBILE_FORM_FACTORS=phone,tablet \
-        --env ACCEPTED_DESKTOP_FORM_FACTORS=desktop \
-        -v `pwd`/test-engineering/contract/volumes/partner:/tmp/partner \
-        -p 5000:5000 \
-        mozilla/contile-integration-tests-partner
-    ```
-4. Start application by running the command below: 
-Note that config settings are contained in the  `sa-test.toml` file.  You may change settings [there](sa-test.toml) that pertain to your local development on Contile.
-```shell
- #! /bin/bash
-RUST_LOG=contile=trace,config=debug \
-    cargo run -- --config sa-test.toml #--debug-settings
-```
-5. Check that the service can accept requests by running:
-```shell
-curl -v http://localhost:8000/v1/tiles -H "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:103.0) Gecko/20100101 Firefox/103.0"
-```
-
-### Running
-
-Contile is configured via environment variables. To see the complete list of available settings in `contile::settings::Settings` (note, you can use `cargo doc --open` to generate documentation.) In general, we have tried to provide sensible default values for most of these,
-however you may need to specify the following:
-
-```
-CONTILE_ADM_ENDPOINT_URL={Your ADM endpoint} \
-    cargo run
-```
-Please note that the `{}` indicate a variable replacement and should not be included, for example, a real environmet variable would look like: `CONTILE_ADM_ENDPOINT_URL=https://example.com/`
 
 ### Testing
 #### Unit Tests

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,3 +1,5 @@
 # Summary
+[Intro](./intro.md)
 
-- [API](./API.md)
+- [API documentation](./api.md)
+- [Developer Setup](./setup.md)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -27,7 +27,6 @@ subgraph ContileDependencies[ ]
     ImageStore
     MaxmindDb
     Filtering
-
 end
 
 subgraph Firefox

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -32,6 +32,4 @@ end
 subgraph Firefox
    NewTab
 end
-
-
 ```

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,38 @@
+# Contile
+
+Contile is a service that fetches tiles to support the Sponsored Tiles feature in Firefox. Sponsored Tiles are a set of display ads appearing on the Firefox New Tab page provided by either a paying partner, or a selected set of other partners.
+
+## Table of Contents
+- [api.md - API Documentation][1]
+- [setup.md - Developer Setup Documentation][2]
+
+[1]: ./api.md
+[2]: ./setup.md
+
+
+## Architecture
+
+```mermaid
+%%{init: {'theme':'dark'}}%%
+flowchart TD
+    Firefox <-->|v1/tiles| Contile
+    Firefox <--> ImageStore[(GCS <br/> Tiles ImageStore)]
+    Contile --> ImageStore
+    Filtering[(GCS <br/> AMP Filtering)] --> Contile
+    Contile <-->|AMP Tiles API Endpoint| AMP["AdMarketplace (AMP)" ]
+    Shepherd -->|AMP settings json| Filtering
+    MaxmindDb[(MaxmindDb)] --> Contile
+subgraph ContileDependencies[ ]
+    Contile
+    ImageStore
+    MaxmindDb
+    Filtering
+
+end
+
+subgraph Firefox
+   NewTab
+end
+
+
+```

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -19,7 +19,7 @@ flowchart TD
     Firefox <--> ImageStore[(GCS <br/> Tiles ImageStore)]
     Contile --> ImageStore
     Filtering[(GCS <br/> AMP Filtering)] --> Contile
-    Contile <-->|AMP Tiles API Endpoint| AMP["AdMarketplace (AMP)" ]
+    Contile <-->|Tiles API| AMP["adMarketplace (AMP)" ]
     Shepherd -->|AMP settings json| Filtering
     MaxmindDb[(MaxmindDb)] --> Contile
 subgraph ContileDependencies[ ]

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,22 +14,27 @@ Contile is a service that fetches tiles to support the Sponsored Tiles feature i
 
 ```mermaid
 %%{init: {'theme':'dark'}}%%
-flowchart TD
-    Firefox <-->|v1/tiles| Contile
-    Firefox <--> ImageStore[(GCS <br/> Tiles ImageStore)]
-    Contile --> ImageStore
-    Filtering[(GCS <br/> AMP Filtering)] --> Contile
-    Contile <-->|Tiles API| AMP["adMarketplace (AMP)" ]
-    Shepherd -->|Setting Files| Filtering
-    MaxmindDb[(MaxmindDb)] --> Contile
-subgraph ContileDependencies[ ]
-    Contile
+flowchart 
+
+subgraph GCS[GCS]
     ImageStore
-    MaxmindDb
     Filtering
 end
-
 subgraph Firefox
-   NewTab
+    NewTab
 end
+
+subgraph ContileDep[ ]
+    Contile
+    GCS
+    MaxmindDb
+end
+
+Firefox <-->|v1/tiles| Contile
+Firefox <--> ImageStore[(Tiles ImageStore)]
+Filtering[(AMP Filtering)] --> Contile 
+Shepherd -->|Settings File| Filtering
+Contile --> MaxmindDb[(MaxmindDb)]
+ImageStore --> Contile
+Contile <-->|Tiles API| AMP["adMarketplace (AMP)"]
 ```

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,7 +20,7 @@ flowchart TD
     Contile --> ImageStore
     Filtering[(GCS <br/> AMP Filtering)] --> Contile
     Contile <-->|Tiles API| AMP["adMarketplace (AMP)" ]
-    Shepherd -->|AMP settings json| Filtering
+    Shepherd -->|Setting Files| Filtering
     MaxmindDb[(MaxmindDb)] --> Contile
 subgraph ContileDependencies[ ]
     Contile

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,7 +12,7 @@ The commit hash of the deployed code is considered its version identifier. The c
 ## Development Setup
 1. Install Rust. See [rustup.rs](https://rustup.rs/) for how to install on your platform.
 2. Compile Contile using `cargo build`.
-3. Start connection a local ADM instance (run from root of Contile repo):
+3. Start a local ADM instance (run from root of Contile repo):
     ```shell
         docker run \
         --env PORT=5000 \

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,47 @@
+## Requirements
+
+This system uses [Actix](https://actix.rs/) web, and Google Cloud APIs (currently vendored).
+
+## Development Guidelines
+Please see the [CONTRIBUTING.md](./CONTRIBUTING.md) docs on commit guidelines and pull request best
+practices.
+
+## Versioning
+The commit hash of the deployed code is considered its version identifier. The commit hash can be retrieved locally via `git rev-parse HEAD`.
+
+## Development Setup
+1. Install Rust. See [rustup.rs](https://rustup.rs/) for how to install on your platform.
+2. Compile Contile using `cargo build`.
+3. Start connection a local ADM instance (run from root of Contile repo):
+    ```shell
+        docker run \
+        --env PORT=5000 \
+        --env RESPONSES_DIR=/tmp/partner/ \
+        --env ACCEPTED_MOBILE_FORM_FACTORS=phone,tablet \
+        --env ACCEPTED_DESKTOP_FORM_FACTORS=desktop \
+        -v `pwd`/test-engineering/contract/volumes/partner:/tmp/partner \
+        -p 5000:5000 \
+        mozilla/contile-integration-tests-partner
+    ```
+4. Start application by running the command below: 
+Note that config settings are contained in the  `sa-test.toml` file.  You may change settings [there](sa-test.toml) that pertain to your local development on Contile.
+```shell
+ #! /bin/bash
+RUST_LOG=contile=trace,config=debug \
+    cargo run -- --config sa-test.toml #--debug-settings
+```
+5. Check that the service can accept requests by running:
+```shell
+curl -v http://localhost:8000/v1/tiles -H "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:103.0) Gecko/20100101 Firefox/103.0"
+```
+
+### Running
+
+Contile is configured via environment variables. To see the complete list of available settings in `contile::settings::Settings` (note, you can use `cargo doc --open` to generate documentation.) In general, we have tried to provide sensible default values for most of these,
+however you may need to specify the following:
+
+```
+CONTILE_ADM_ENDPOINT_URL={Your ADM endpoint} \
+    cargo run
+```
+Please note that the `{}` indicate a variable replacement and should not be included, for example, a real environmet variable would look like: `CONTILE_ADM_ENDPOINT_URL=https://example.com/`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -44,4 +44,4 @@ however you'll need to specify the ADM endpoint URL:
 CONTILE_ADM_ENDPOINT_URL={Your ADM endpoint} \
     cargo run
 ```
-Please note that the `{}` indicate a variable replacement and should not be included, for example, a real environmet variable would look like: `CONTILE_ADM_ENDPOINT_URL=https://example.com/`
+Please note that the `{}` indicates a variable replacement, and should not be included. For example, a real environment variable would look like: `CONTILE_ADM_ENDPOINT_URL=https://example.com/`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,8 +37,8 @@ curl -v http://localhost:8000/v1/tiles -H "User-Agent:Mozilla/5.0 (Windows NT 10
 
 ### Running
 
-Contile is configured via environment variables. To see the complete list of available settings in `contile::settings::Settings` (note, you can use `cargo doc --open` to generate documentation.) In general, we have tried to provide sensible default values for most of these,
-however you may need to specify the following:
+Contile is configured via config files and environment variables. For the complete list of available settings, please see [`contile::settings::Settings`](src/settings.rs) (note, you can use `cargo doc --open` to generate documentation.) In general, we have tried to provide sensible default values for most of these,
+however you'll need to specify the ADM endpoint URL:
 
 ```
 CONTILE_ADM_ENDPOINT_URL={Your ADM endpoint} \


### PR DESCRIPTION
## References

JIRA: [DISCO-2506](https://mozilla-hub.atlassian.net/browse/DISCO-2506)

## Description
Moved some setup docs into its own separate doc.  Was not sure when the tickets says to call out MaxmindDb whether having it in the architecture diagram was sufficient. Diagram uses the theme "dark" since i found the arrows were hard to see in the default theme against a dark background.

![Screenshot 2023-08-02 at 10 23 58 AM](https://github.com/mozilla-services/contile/assets/25379936/a6685381-27a1-43c0-8c24-9fff3cf309bf)



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [ ] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [ ] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [ ] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2506]: https://mozilla-hub.atlassian.net/browse/DISCO-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ