### PR TITLE
Add rollback documentation for Contile

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,3 +3,5 @@
 
 - [API documentation](./api.md)
 - [Developer Setup](./setup.md)
+- [Operations and Runbooks](./operations/index.md)
+  - [Rollback](./operations/rollback.md)

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,0 +1,3 @@
+# Operations and Runbooks
+
+This is where we put all our operational documentation.

--- a/docs/operations/rollback.md
+++ b/docs/operations/rollback.md
@@ -1,0 +1,14 @@
+# How to Rollback Changes
+
+Note: We use "roll-forward" strategy for rolling back changes in production.
+
+1. Depending on the severity of the problem, decide if this warrants
+   [kicking off an incident][incident_docs];
+2. Identify the problematic commit and create a revert PR.
+   If it is the latest commit, you can revert the change with:
+   ```
+   git revert HEAD~1
+   ```
+3. Create a revert PR and go through normal review process to merge PR.
+
+[incident_docs]: https://mozilla-hub.atlassian.net/wiki/spaces/MIR/overview


### PR DESCRIPTION
## References

JIRA: [DISCO-2513](https://mozilla-hub.atlassian.net/browse/DISCO-2513)


## Description
Add some documentation on how we should perform a rollback on Contile.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [ ] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [ ] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [ ] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2513]: https://mozilla-hub.atlassian.net/browse/DISCO-2513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ