### PR TITLE
[DISCO-2572] remove github link from pr template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,6 @@
 ## References
 
 JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)
-GitHub: [#TODO](https://github.com/mozilla-services/contile/issues/TODO)
 
 ## Description
 <!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, etc .... -->


### PR DESCRIPTION
## References

JIRA: [DISCO-2572](https://mozilla-hub.atlassian.net/browse/DISCO-2572)

## Description
Remove the GitHub issue link from the Pull Request Templates



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [ ] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [ ] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [ ] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2572]: https://mozilla-hub.atlassian.net/browse/DISCO-2572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ