### PR TITLE
[DISCO-2518]: Drop the excluded_countries_200 setting

### DIFF
--- a/src/adm/filter.rs
+++ b/src/adm/filter.rs
@@ -55,7 +55,6 @@ pub struct AdmFilter {
     pub last_updated: Option<chrono::DateTime<chrono::Utc>>,
     pub refresh_rate: Duration,
     pub defaults: AdmDefaults,
-    pub excluded_countries_200: bool,
 }
 
 /// Parse &str into a `Url`

--- a/src/adm/settings.rs
+++ b/src/adm/settings.rs
@@ -453,7 +453,6 @@ impl From<&mut Settings> for HandlerResult<AdmFilter> {
         } else {
             Default::default()
         };
-        let excluded_countries_200 = settings.excluded_countries_200;
         let settings_str = if Path::new(&settings.adm_settings).exists() {
             read_to_string(&settings.adm_settings)
                 .map_err(|e| {
@@ -509,7 +508,6 @@ impl From<&mut Settings> for HandlerResult<AdmFilter> {
             source_url,
             refresh_rate: std::time::Duration::from_secs(refresh_rate),
             defaults,
-            excluded_countries_200,
         })
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -89,10 +89,6 @@ pub struct Settings {
     pub connect_timeout: u64,
     /// default total request timeout (in seconds)
     pub request_timeout: u64,
-    /// Whether excluded countries recieve empty tile responses via an HTTP 200
-    /// status code or 204s when disabled. See
-    /// https://github.com/mozilla-services/contile/issues/284
-    pub excluded_countries_200: bool,
     /// Whether Tiles responses may include a `Cache-Control` header
     pub cache_control_header: bool,
 
@@ -169,7 +165,6 @@ impl Default for Settings {
             exclude_dma: Some("[798, 583, 740]".to_owned()),
             connect_timeout: 2,
             request_timeout: 5,
-            excluded_countries_200: false,
             cache_control_header: true,
             // ADM specific settings
             adm_endpoint_url: "".to_owned(),

--- a/src/web/test.rs
+++ b/src/web/test.rs
@@ -426,7 +426,6 @@ async fn basic_all_bad_reply() {
         adm_settings: AdmFilter::advertisers_to_string(advertiser_filters()),
         ..get_test_settings()
     };
-    settings.excluded_countries_200 = false;
     let app = init_app!(settings).await;
 
     let req = test::TestRequest::get()
@@ -699,7 +698,6 @@ async fn empty_tiles() {
         adm_settings: adm_settings_json.to_string(),
         ..get_test_settings()
     };
-    settings.excluded_countries_200 = false;
     let app = init_app!(settings).await;
 
     let req = test::TestRequest::get()
@@ -716,81 +714,12 @@ async fn empty_tiles() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
-}
-
-#[actix_web::test]
-async fn empty_tiles_returns_no_content() {
-    let adm = init_mock_adm(MOCK_RESPONSE1.to_owned());
-    let filters = json!({"adm_advertisers":{
-        "Acme": {
-            "US":[
-                { "host": "www.foo.bar" }
-            ]
-         },
-        "Dunder Mifflin": {
-        },
-        "Los Pollos Hermanos": {
-        },
-    }
-
-    })
-    .to_string();
-    let adm_settings = filters;
-    let mut settings = Settings {
-        adm_endpoint_url: adm.endpoint_url,
-        excluded_countries_200: true,
-        adm_settings,
-        ..get_test_settings()
-    };
-    let app = init_app!(settings).await;
-
-    let req = test::TestRequest::get()
-        .uri("/v1/tiles")
-        .insert_header((header::USER_AGENT, UA_91))
-        .to_request();
-    let resp = test::call_service(&app, req).await;
-
-    let content_type = resp.headers().get(header::CONTENT_TYPE);
-    assert!(content_type.is_some());
-    assert_eq!(
-        content_type
-            .unwrap()
-            .to_str()
-            .expect("Couldn't parse Content-Type"),
-        "application/json"
-    );
-    assert_eq!(resp.status(), StatusCode::OK);
-    let result: Value = test::read_body_json(resp).await;
-    let tiles = result["tiles"].as_array().expect("!tiles.is_array()");
-    assert_eq!(tiles.len(), 0);
-
-    // Ensure same result from cache
-    let req = test::TestRequest::get()
-        .uri("/v1/tiles")
-        .insert_header((header::USER_AGENT, UA_91))
-        .to_request();
-    let resp = test::call_service(&app, req).await;
-
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let content_type = resp.headers().get(header::CONTENT_TYPE);
-    assert!(content_type.is_some());
-    assert_eq!(
-        content_type
-            .unwrap()
-            .to_str()
-            .expect("Couldn't parse Content-Type"),
-        "application/json"
-    );
-    let result: Value = test::read_body_json(resp).await;
-    let tiles = result["tiles"].as_array().expect("!tiles.is_array()");
-    assert_eq!(tiles.len(), 0);
 }
 
 #[actix_web::test]
 async fn empty_tiles_excluded_country() {
-    // ensure that a response where all candidate tiles have been filtered
-    // out returns a 200 response.
+    // A response where all candidate tiles have been filtered out returns a
+    // 204 response.
     let adm = init_mock_adm(MOCK_RESPONSE1.to_owned());
     // Specify valid advertisers with no per country information. This will
     // "exclude" US locations.
@@ -809,40 +738,6 @@ async fn empty_tiles_excluded_country() {
     let mut settings = Settings {
         adm_endpoint_url: adm.endpoint_url,
         adm_settings,
-        excluded_countries_200: true,
-        ..get_test_settings()
-    };
-    let app = init_app!(settings).await;
-
-    let req = test::TestRequest::get()
-        .uri("/v1/tiles")
-        .insert_header((header::USER_AGENT, UA_91))
-        .to_request();
-    let resp = test::call_service(&app, req).await;
-    assert_eq!(resp.status(), StatusCode::OK);
-    let result: Value = test::read_body_json(resp).await;
-    let tiles = result["tiles"].as_array().expect("!tiles.is_array()");
-    assert_eq!(tiles.len(), 0);
-
-    // Ensure same result from cache
-    let req = test::TestRequest::get()
-        .uri("/v1/tiles")
-        .insert_header((header::USER_AGENT, UA_91))
-        .to_request();
-    let resp = test::call_service(&app, req).await;
-    assert_eq!(resp.status(), StatusCode::OK);
-    let result: Value = test::read_body_json(resp).await;
-    let tiles = result["tiles"].as_array().expect("!tiles.is_array()");
-    assert_eq!(tiles.len(), 0);
-}
-
-#[actix_web::test]
-async fn empty_tiles_excluded_country_204() {
-    let adm = init_mock_adm(MOCK_RESPONSE1.to_owned());
-    // no adm_settings filters everything out, the client's country (US) is
-    // considered "excluded"
-    let mut settings = Settings {
-        adm_endpoint_url: adm.endpoint_url,
         ..get_test_settings()
     };
     let app = init_app!(settings).await;
@@ -881,7 +776,6 @@ async fn include_regions() {
     let mut settings = Settings {
         adm_endpoint_url: adm.endpoint_url,
         adm_settings: AdmFilter::advertisers_to_string(adm_settings),
-        excluded_countries_200: false,
         ..get_test_settings()
     };
     let app = init_app!(settings).await;
@@ -1181,7 +1075,6 @@ async fn no_sov() {
 
     let mut settings = Settings {
         adm_endpoint_url: adm.endpoint_url,
-        excluded_countries_200: true,
         sov_source: "gs://bad.bucket".to_owned(),
         ..get_test_settings()
     };
@@ -1192,13 +1085,5 @@ async fn no_sov() {
         .insert_header((header::USER_AGENT, UA_91))
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let content_type = resp.headers().get(header::CONTENT_TYPE);
-    assert!(content_type.is_some());
-
-    let result: Value = test::read_body_json(resp).await;
-
-    let sov = result["sov"].as_str();
-    assert_eq!(sov, None)
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 }

--- a/test-engineering/contract/docker-compose.204.yml
+++ b/test-engineering/contract/docker-compose.204.yml
@@ -1,9 +1,6 @@
 version: "3"
 
 services:
-  contile:
-    environment:
-      CONTILE_EXCLUDED_COUNTRIES_200: 0
   client:
     environment:
       SCENARIOS_FILE: /tmp/client/scenarios_204.yml

--- a/test-engineering/contract/volumes/client/scenarios_204.yml
+++ b/test-engineering/contract/volumes/client/scenarios_204.yml
@@ -1,9 +1,8 @@
 scenarios:
   - name: success_204_No_Content_exluded_region
     description: Test that Contile returns a 204 No Content for excluded regions
-    # This test uses the Environment Flag "CONTILE_EXCLUDED_COUNTRIES_200" (specified
-    # in the `docker-compose.204.yml` file) and checks that Contile returns a 204 with
-    # no content if a request is made from an excluded country location.
+    # This test checks that Contile returns a 204 with no content if a request is made from an
+    # excluded country location.
     steps:
       - request:
           service: contile


### PR DESCRIPTION
## References

JIRA: [DISCO-2518](https://mozilla-hub.atlassian.net/browse/DISCO-2518)

## Description

This is no longer needed as Firefox 115 and later correctly handle a 204 response.

This reverts #290 and #479.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/contile/blob/main/CONTRIBUTING.md)
- [x] This PR conforms to the [Opsec policies](https://github.com/mozilla-services/websec-check)
- [x] [Functional and performance test](https://github.com/mozilla-services/contile/tree/main/test-engineering) coverage has been expanded and maintained (if applicable)
- [ ] The `[load test: (abort|warn)]` keywords are applied (if applicable)
- [ ] Documentation has been updated
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title


[DISCO-2518]: https://mozilla-hub.atlassian.net/browse/DISCO-2518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ